### PR TITLE
Fix: Show proper toast message when liking/disliking/reporting own post and other posts

### DIFF
--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/comment/CommentScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/comment/CommentScreen.kt
@@ -172,7 +172,7 @@ fun CommentScreen(
     LaunchedEffect(sheetState.value) {
         val content = (sheetState.value as? CommentViewModel.State.Content?)
         if (content?.error != null) {
-            Toast.makeText(context, content.error.message, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, content.error.message?.let { component.resource().string(it) }, Toast.LENGTH_SHORT).show()
             viewModel.reset()
         }
     }

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/engagement/EngagementScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/engagement/EngagementScreen.kt
@@ -94,18 +94,10 @@ fun EngagementScreen(
             viewModel.reset()
         }
     }
-
-    //HERE THE ERROR MAPPING HAS BEEN IMPLEMENTED
     LaunchedEffect(hasError.value) {
         if (hasError.value) {
-            val message = component.resource().string(
-                when ((state as? EngagementViewModel.State.Error)?.error?.message) {
-                    "21601" -> "error.cannot_like_own_post"
-                    "21602" -> "error.cannot_dislike_own_post"
-                    else -> (state as? EngagementViewModel.State.Error)?.error?.message.orEmpty()
-                }
-            )
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            val error = (state as? EngagementViewModel.State.Error)?.error?.message
+            Toast.makeText(context, error?.let { component.resource().string(it) } ?: errorMessage, Toast.LENGTH_SHORT).show()
             viewModel.clear()
         }
     }

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/engagement/EngagementScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/engagement/EngagementScreen.kt
@@ -94,12 +94,22 @@ fun EngagementScreen(
             viewModel.reset()
         }
     }
+
+    //HERE THE ERROR MAPPING HAS BEEN IMPLEMENTED
     LaunchedEffect(hasError.value) {
         if (hasError.value) {
-            Toast.makeText(context, error.value?.message ?: errorMessage, Toast.LENGTH_SHORT).show()
+            val message = component.resource().string(
+                when ((state as? EngagementViewModel.State.Error)?.error?.message) {
+                    "21601" -> "error.cannot_like_own_post"
+                    "21602" -> "error.cannot_dislike_own_post"
+                    else -> (state as? EngagementViewModel.State.Error)?.error?.message.orEmpty()
+                }
+            )
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             viewModel.clear()
         }
     }
+
     CommentScreen(
         tag,
         post,

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/moderation/ModerationScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/moderation/ModerationScreen.kt
@@ -50,28 +50,19 @@ fun ModerationScreen(
     val success by remember { derivedStateOf { state as? ModerationViewModel.State.Success? } }
     val message = stringResource(eu.peernetwork.blog.ui.R.string.action_message)
     val updatedContent by rememberUpdatedState(content)
-
     updatedContent(
         ModerationSpec(
             onSave = { viewModel.save(it) },
             onReport = { viewModel.report(it) }
         )
     )
-
     LaunchedEffect(error, success) {
         success?.postId?.let {
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             viewModel.reset()
         }
-
-        error?.error?.let {
-            val resolvedMessage = component.resource().string(
-                when (it.message) {
-                    "21901" -> "error.cannot_report_own_post"
-                    else -> it.message.orEmpty()
-                }
-            )
-            Toast.makeText(context, resolvedMessage, Toast.LENGTH_SHORT).show()
+        error?.error?.message?.let {
+            Toast.makeText(context, component.resource().string(it), Toast.LENGTH_SHORT).show()
             viewModel.reset()
         }
     }

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/moderation/ModerationScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/moderation/ModerationScreen.kt
@@ -10,14 +10,7 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -25,12 +18,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import eu.peernetwork.blog.ui.model.UiContent
 import eu.peernetwork.core.ui.R
 import eu.peernetwork.core.ui.component.UiComponentProvider
 import eu.peernetwork.core.ui.design.compose.DesignTextButton
 import eu.peernetwork.core.ui.extension.builder
-import androidx.lifecycle.viewmodel.compose.viewModel
-import eu.peernetwork.blog.ui.model.UiContent
 
 data class ModerationSpec(
     val onReport: (String) -> Unit,
@@ -57,19 +50,28 @@ fun ModerationScreen(
     val success by remember { derivedStateOf { state as? ModerationViewModel.State.Success? } }
     val message = stringResource(eu.peernetwork.blog.ui.R.string.action_message)
     val updatedContent by rememberUpdatedState(content)
+
     updatedContent(
         ModerationSpec(
             onSave = { viewModel.save(it) },
             onReport = { viewModel.report(it) }
         )
     )
+
     LaunchedEffect(error, success) {
         success?.postId?.let {
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
             viewModel.reset()
         }
+
         error?.error?.let {
-            Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+            val resolvedMessage = component.resource().string(
+                when (it.message) {
+                    "21901" -> "error.cannot_report_own_post"
+                    else -> it.message.orEmpty()
+                }
+            )
+            Toast.makeText(context, resolvedMessage, Toast.LENGTH_SHORT).show()
             viewModel.reset()
         }
     }
@@ -81,6 +83,7 @@ fun ModerationScreen(
     spec: ModerationSpec
 ) {
     var expanded by remember { mutableStateOf(false) }
+
     Box {
         DesignTextButton(
             onClick = { expanded = true },
@@ -93,6 +96,7 @@ fun ModerationScreen(
                 modifier = Modifier.size(28.dp)
             )
         }
+
         DropdownMenu(
             modifier = Modifier.background(color = MaterialTheme.colorScheme.background),
             expanded = expanded,
@@ -105,11 +109,12 @@ fun ModerationScreen(
                     spec.onReport(model.id)
                 }
             )
+// Uncomment this if you want to allow Save option later
 //            DropdownMenuItem(
 //                text = { Text("Save") },
 //                onClick = {
 //                    expanded = false
-//                    viewModel.save(content.id)
+//                    spec.onSave(model.id)
 //                }
 //            )
         }


### PR DESCRIPTION
## 📝 Description:

- This pull request addresses how errors are communicated to the user when performing moderation actions such as reporting, liking, or disliking content.

## ✅ What’s Changed:

- Implemented Toast messages to show errors clearly when moderation actions fail.
- Toast content is now localized using component.resource().string(it) instead of showing raw error strings or nulls.
- The error handling logic is placed inside LaunchedEffect, which reacts to error/success state changes and handles the reset logic after feedback is shown.

## 🎯 Why This Matters:

- Users will now receive clear, translated messages instead of technical or missing error texts.
