### PR TITLE
feat(registration): add age confirmation modal for 18+ compliance

### DIFF
--- a/user/ui/src/main/kotlin/eu/peernetwork/user/ui/registeration/RegistrationScreen.kt
+++ b/user/ui/src/main/kotlin/eu/peernetwork/user/ui/registeration/RegistrationScreen.kt
@@ -1,11 +1,16 @@
 package eu.peernetwork.user.ui.registeration
 
+import androidx.compose.runtime.saveable.rememberSaveable
 import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.AlertDialog
+//import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,7 +22,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -62,6 +68,7 @@ fun RegistrationScreen(
             component.resource().string(it)
         }
     } }
+
     RegistrationScreen(
         referral = referral,
         loading = loading,
@@ -70,6 +77,7 @@ fun RegistrationScreen(
     ) { email, username, password, referral ->
         viewModel.register(username, email, password, referral)
     }
+
     LaunchedEffect(state) {
         if (state is RegistrationViewModel.State.Success) {
             Toast.makeText(context, successMessage, Toast.LENGTH_SHORT).show()
@@ -87,11 +95,16 @@ fun RegistrationScreen(
     onSubmit: (String, String, String, String) -> Unit
 ) {
     val email by rememberSaveable(stateSaver = TextFieldState.Saver) { mutableStateOf(TextFieldState()) }
-    val username by rememberSaveable(stateSaver = TextFieldState.Saver) { mutableStateOf(TextFieldState()) }
+    val username by rememberSaveable(stateSaver = TextFieldState.Saver) {
+        mutableStateOf(
+            TextFieldState()
+        )
+    }
     val referralCode by rememberSaveable(stateSaver = TextFieldState.Saver) {
         mutableStateOf(referral?.let { TextFieldState(it) } ?: TextFieldState())
     }
     var password = remember { TextFieldState() }
+
     val validate by remember(email, username, password) {
         derivedStateOf {
             email.isValidEmail() &&
@@ -99,8 +112,13 @@ fun RegistrationScreen(
                     password.passwordStrength().value >= DesignPasswordStrength.STRONG.value
         }
     }
+
     val handleReset by rememberUpdatedState(onReset)
     val handleSubmit by rememberUpdatedState(onSubmit)
+
+    // State to control showing age confirmation dialog
+    val showAgeConfirmDialog = remember { mutableStateOf(false) }
+
     Column(modifier = Modifier.fillMaxWidth()) {
         RegistrationForm(
             email = email,
@@ -110,16 +128,13 @@ fun RegistrationScreen(
             error = error.value,
             enabled = !loading.value,
         )
+
         DesignButton(
             enabled = !loading.value && validate,
             isLoading = loading.value,
             onClick = {
-                handleSubmit(
-                    email.text.toString(),
-                    username.text.toString(),
-                    password.text.toString(),
-                    referralCode.text.toString()
-                )
+                // Show age confirmation popup on register button click?
+                showAgeConfirmDialog.value = true
             },
             modifier = Modifier
                 .fillMaxWidth()
@@ -134,6 +149,49 @@ fun RegistrationScreen(
             )
         }
     }
+
+    // Age confirmation popup dialog appears
+    if (showAgeConfirmDialog.value) {
+        var isChecked by remember { mutableStateOf(false) }
+        AlertDialog(
+            onDismissRequest = { /* Prevent dismiss by clicking outside or back button */ },
+            title = { Text(text = stringResource(id = R.string.age_confirmation_title)) },
+            text = {
+                Column {
+                    Text(text = stringResource(id = R.string.age_confirmation_message))
+
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(top = 8.dp)
+                    ) {
+                        Checkbox(
+                            checked = isChecked,
+                            onCheckedChange = { isChecked = it }
+                        )
+                        Text(text = stringResource(id = R.string.age_confirmation_checkbox))
+                    }
+                }
+            },
+            confirmButton = {
+                DesignButton(
+                    enabled = isChecked,
+                    onClick = {
+                        showAgeConfirmDialog.value = false
+                        // Proceed with registration after age confirmation
+                        handleSubmit(
+                            email.text.toString(),
+                            username.text.toString(),
+                            password.text.toString(),
+                            referralCode.text.toString()
+                        )
+                    }
+                ) {
+                    Text(text = stringResource(id = R.string.age_confirmation_continue))
+                }
+            }
+        )
+    }
+
     DisposableEffect(email) { onDispose { handleReset?.invoke() } }
 }
 
@@ -141,7 +199,7 @@ fun RegistrationScreen(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun PreviewRegistrationScreen() {
     PeerTheme {
-        val isLoading = remember { mutableStateOf<Boolean>(false) }
+        val isLoading = remember { mutableStateOf(false) }
         val error = remember { mutableStateOf<String?>(null) }
         RegistrationScreen(isLoading, error) { email, username, password, referral -> }
     }

--- a/user/ui/src/main/res/values/strings.xml
+++ b/user/ui/src/main/res/values/strings.xml
@@ -23,6 +23,13 @@
     <string name="empty_description_message">Biography unavailable</string>
     <string name="referral_label">Referral Code (Optional)</string>
     <string name="referral_code_label">Referral Code (Optional)</string>
-
+    //Referral
     <string name="referral_copy_message">Referral link copied</string>
+    //Age Confirmation
+    <string name="age_confirmation_checkbox">I confirm that I am 18 years or older.</string>
+    <string name="age_confirmation_title">Age Confirmation</string>
+    <string name="age_confirmation_continue">Continue</string>
+    <string name="age_confirmation_message">You must be 18 years or older to use this app.</string>
+
+
 </resources>


### PR DESCRIPTION
# 🚀 Feature: Age Confirmation Modal (18+)
## Summary
This PR adds a mandatory age confirmation modal to the registration process.
Users must confirm they are 18+ after clicking the Register button to continue.

## Changes
- Shows a blocking popup after Register is clicked
- Message:
`"You must be 18 years or older to use this app."`
- Checkbox:
`"I confirm that I am 18 years or older."`
- “Continue” button is disabled until checkbox is checked
- Prevents registration until confirmation
- All texts moved to strings.xml for localization

## User Story

> As a Peer Network user,
> I want to see a mandatory pop-up confirming I am over 18 years old before using the app,
> So that the platform complies with government regulations.

## Scenario
✅ Given: I'm on the registration screen
✅ When: I click the "Register" button
✅ Then: A modal appears asking for 18+ confirmation
✅ And: I cannot proceed until I check the box
