### PR TITLE
Srivetrikumaran/feat/add privacy policy url buildconfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,7 @@ android {
             useSupportLibrary = true
         }
         buildConfigField("int", "PAGING_LIMIT", "20")
+
     }
     buildTypes {
         debug {
@@ -22,6 +23,7 @@ android {
             buildConfigField("String", "MEDIA_URL", "\"https://media.getpeer.eu\"")
             buildConfigField("String", "INVITE_URL", "\"https://testing.getpeer.eu/invite.php?%s\"")
             buildConfigField("boolean", "USE_SYSTEM_THEME", "false")
+            buildConfigField("String","PRIVACY_POLICY_URL","\"https://www.freeprivacypolicy.com/live/02865c3a-79db-4baf-9ca1-7d91e2cf1724\"")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
         release {
@@ -31,6 +33,7 @@ android {
             buildConfigField("String", "MEDIA_URL", "\"https://media.peernetwork.eu\"")
             buildConfigField("String", "INVITE_URL", "\"https://testing.getpeer.eu/invite.php?%s\"")
             buildConfigField("boolean", "USE_SYSTEM_THEME", "false")
+            buildConfigField("String","PRIVACY_POLICY_URL","\"https://www.freeprivacypolicy.com/live/02865c3a-79db-4baf-9ca1-7d91e2cf1724\"")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfig = signingConfigs.getByName("debug")
         }
@@ -82,6 +85,7 @@ dependencies {
     implementation(libs.firebase.messaging)
 
     implementation(libs.lottie)
+
 
     implementation(libs.dagger)
     ksp(libs.dagger.compiler)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 
 android {
     defaultConfig {
-        versionCode = 7
-        versionName = "1.0.7"
+        versionCode = 9
+        versionName = "1.0.9"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/Privacy.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/Privacy.kt
@@ -1,0 +1,23 @@
+package eu.peernetwork.app.ui.privacy
+
+import android.content.Context
+import eu.peernetwork.core.ui.component.UiComponent
+
+interface Privacy {
+    @javax.inject.Scope
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class Scope
+
+    @Scope
+    @dagger.Component(
+        dependencies = [ Privacy::class ],
+        modules = [ PrivacyModule::class ]
+    )
+    interface Component : Privacy
+
+    class Builder(private val dependency: Privacy) : UiComponent.DefaultBuilder<Privacy, Component>() {
+        override fun build(context: Context): Component {
+            return DaggerPrivacy_Component.builder().privacy(dependency).build()
+        }
+    }
+}

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyModule.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyModule.kt
@@ -1,0 +1,6 @@
+package eu.peernetwork.app.ui.privacy
+
+import dagger.Module
+
+@Module
+object PrivacyModule

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyScreen.kt
@@ -1,19 +1,44 @@
 package eu.peernetwork.app.ui.privacy
 
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
-import eu.peernetwork.core.ui.design.compose.DesignTitle
-import eu.peernetwork.core.ui.design.compose.DesignTitleBarHost
-import eu.peernetwork.user.ui.R
+import android.annotation.SuppressLint
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.viewinterop.AndroidView
+import eu.peernetwork.app.BuildConfig
 
+@SuppressLint("SetJavaScriptEnabled")
 @Composable
-fun PrivacyScreen(onFinish: () -> Unit) {
-    DesignTitleBarHost("PasswordRequestScreen", onFinish) {
-        titleBar {
-            DesignTitle {
-                Text(stringResource(R.string.password_recovery_label))
-            }
+fun PrivacyScreen(onBack: () -> Unit) {
+    BackHandler(onBack = onBack)
+    val context = LocalContext.current
+    var webView by remember { mutableStateOf(WebView(context).apply {
+        settings.javaScriptEnabled = true
+        webViewClient = WebViewClient()
+         }
+       )
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+//            .navigationBarsPadding()
+//            .statusBarsPadding()
+              .systemBarsPadding()
+    ) {
+        Box(modifier = Modifier.fillMaxSize().clipToBounds()){
+            AndroidView(
+                factory = { webView.also {
+                            webView.loadUrl(
+                            BuildConfig.PRIVACY_POLICY_URL    //BuildConfig created for Privacy policy URL
+                            )   //webView.loadUrl("https://www.freeprivacypolicy.com/live/02865c3a-79db-4baf-9ca1-7d91e2cf1724")
+                     }
+                }
+            )
         }
     }
 }

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyScreen.kt
@@ -1,0 +1,19 @@
+package eu.peernetwork.app.ui.privacy
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import eu.peernetwork.core.ui.design.compose.DesignTitle
+import eu.peernetwork.core.ui.design.compose.DesignTitleBarHost
+import eu.peernetwork.user.ui.R
+
+@Composable
+fun PrivacyScreen(onFinish: () -> Unit) {
+    DesignTitleBarHost("PasswordRequestScreen", onFinish) {
+        titleBar {
+            DesignTitle {
+                Text(stringResource(R.string.password_recovery_label))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/setup/Setup.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/setup/Setup.kt
@@ -3,6 +3,7 @@ package eu.peernetwork.app.ui.setup
 import android.content.Context
 import androidx.lifecycle.ViewModelProvider
 import eu.peernetwork.app.provider.ApplicationProvider
+import eu.peernetwork.app.ui.privacy.Privacy
 import eu.peernetwork.core.ui.component.UiComponent
 import eu.peernetwork.core.ui.component.UiComponentProvider
 import eu.peernetwork.user.ui.login.Login
@@ -19,7 +20,7 @@ interface Setup : ApplicationProvider {
         dependencies = [ Setup::class ],
         modules = [ SetupModule::class ]
     )
-    interface Component : Setup, Login, Registration, PasswordRequest, UiComponentProvider {
+    interface Component : Setup, Login, Registration, PasswordRequest, Privacy, UiComponentProvider {
         fun viewModelFactory(): ViewModelProvider.Factory
     }
 

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/setup/SetupModule.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/setup/SetupModule.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
+import eu.peernetwork.app.ui.privacy.Privacy
 import eu.peernetwork.core.ui.annotation.UiBuilder
 import eu.peernetwork.core.ui.annotation.UiViewModel
 import eu.peernetwork.core.ui.component.UiComponent
@@ -59,5 +60,13 @@ object SetupModule {
     @UiBuilder(PasswordRequest.Builder::class)
     fun providePasswordRequestBuilder(component: Setup.Component): UiComponent.Builder {
         return PasswordRequest.Builder(component)
+    }
+
+    @Setup.Scope
+    @Provides
+    @IntoMap
+    @UiBuilder(Privacy.Builder::class)
+    fun providePrivacyBuilder(component: Setup.Component): UiComponent.Builder {
+        return Privacy.Builder(component)
     }
 }

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/setup/SetupNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/setup/SetupNavigation.kt
@@ -8,8 +8,10 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import eu.peernetwork.app.ui.privacy.PrivacyScreen
 import eu.peernetwork.core.ui.component.UiComponentProvider
 import eu.peernetwork.core.ui.design.compose.DesignRouter
+import eu.peernetwork.core.ui.design.compose.DesignTitleBar
 import eu.peernetwork.user.ui.password.request.PasswordRequestScreen
 
 @Composable
@@ -24,6 +26,11 @@ fun SetupNavigation(
         startDestination = "setup",
     ) {
         composable("setup") { updatedSetup(controller) }
+        composable("privacy") {
+            DesignTitleBar {
+                PrivacyScreen { controller.popBackStack() }
+            }
+        }
         composable(
             "passwordRequest/{email}",
             arguments = listOf(navArgument("email") {

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/setup/SetupScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/setup/SetupScreen.kt
@@ -58,7 +58,9 @@ fun SetupScreen(
         DesignContainer {
             SetupScaffold(
                 header = { SetupHeader(state = contentState) },
-                footer = { SetupFooter(onPrivacy = {}) },
+                footer = { SetupFooter(onPrivacy = {
+                    controller.navigateIfNecessary("privacy")
+                }) },
                 modifier = Modifier.padding(bottom = imeHeight.dp)
             ) {
                 SetupScreen(


### PR DESCRIPTION
### What is done?
 - Configured and Implemented URL to "Privacy Policy"
- Status Bar and Navigation Bar have been fixed to maintain clean look 
- Added `PRIVACY_POLICY_URL` constant in `build.gradle` (app module) under `buildConfigField`
- Updated `PrivacyScreen.kt` to load the privacy policy URL dynamically from `BuildConfig` instead of hardcoded string

### Testing

- Verified the PrivacyScreen loads the URL correctly
- No UI changes expected besides loading URL from new source

### Notes
- Remember to sync Gradle after merging for `BuildConfig` changes to take effect
