### PR TITLE
feat(settings): add About Us screen with version info and branding

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/settings/AboutUsScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/settings/AboutUsScreen.kt
@@ -1,0 +1,108 @@
+package eu.peernetwork.app.ui.settings
+
+import eu.peernetwork.app.BuildConfig
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+//import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import eu.peernetwork.core.ui.design.compose.DesignTitle
+import eu.peernetwork.core.ui.design.compose.DesignTitleBarHost
+import eu.peernetwork.core.ui.theme.PeerTheme
+import eu.peernetwork.user.ui.R
+
+@Composable
+fun AboutUsScreen() {
+    val versionName = BuildConfig.VERSION_NAME
+    val versionCode = BuildConfig.VERSION_CODE
+
+    DesignTitleBarHost("AboutUs") {
+        titleBar {
+            DesignTitle {
+                Text(
+                    text = stringResource(R.string.about_us_label),
+                    // style = MaterialTheme.typography.headlineSmall,
+                    // color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Icon(
+            painter = painterResource(id = eu.peernetwork.app.R.drawable.ic_icon),
+            contentDescription = stringResource(R.string.about_us_label),
+            modifier = Modifier.size(52.dp),
+            tint = MaterialTheme.colorScheme.onBackground
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Nested Column for left-aligned text under the icon
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                text = "\"${stringResource(R.string.about_us_description_label)}\"",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text =  stringResource(R.string.app_information_label),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text =  stringResource(R.string.app_name_label),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "${stringResource(R.string.version_text_label)} $versionName ($versionCode)",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text =  stringResource(R.string.developed_by_label),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text =  stringResource(R.string.copyright_label),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun PreviewAboutUsScreen() {
+    PeerTheme {
+        AboutUsScreen()
+    }
+}

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/settings/SettingsItem.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/settings/SettingsItem.kt
@@ -2,13 +2,7 @@ package eu.peernetwork.app.ui.settings
 
 import android.content.res.Configuration
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -35,7 +29,8 @@ fun ColumnScope.SettingsItem(
     val border = MaterialTheme.colorScheme.tertiaryContainer
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.clickable(role = Role.Button, onClick = onClick)
+        modifier = Modifier
+            .clickable(role = Role.Button, onClick = onClick)
             .drawBehind {
                 val strokeWidth = 1.dp.toPx()
                 drawLine(
@@ -44,7 +39,8 @@ fun ColumnScope.SettingsItem(
                     end = Offset(size.width, size.height),
                     strokeWidth = strokeWidth
                 )
-            }.padding(horizontal = 24.dp, vertical = 10.dp)
+            }
+            .padding(horizontal = 24.dp, vertical = 10.dp)
     ) {
         Text(
             label,
@@ -58,7 +54,8 @@ fun ColumnScope.SettingsItem(
             painterResource(eu.peernetwork.core.ui.R.drawable.ic_next),
             contentDescription = stringResource(R.string.referral_label),
             tint = MaterialTheme.colorScheme.surfaceDim.copy(alpha = .6f),
-            modifier = Modifier.size(32.dp)
+            modifier = Modifier
+                .size(32.dp)
                 .padding(8.dp)
         )
     }
@@ -68,7 +65,8 @@ fun ColumnScope.SettingsItem(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun PreviewSettingsItem() {
     PeerTheme {
-        Column(modifier = Modifier.fillMaxSize()
+        Column(modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState())) {
             SettingsItem("Settings") {}
         }

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/settings/SettingsNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/settings/SettingsNavigation.kt
@@ -26,17 +26,25 @@ fun SettingsNavigation(
     val password = stringResource(R.string.password_label)
     val preference = stringResource(R.string.preference_label)
     val account = stringResource(R.string.account_label)
+
     DesignRouter(
         navController = controller,
         startDestination = "settings",
     ) {
         composable("settings") { updatedSettings(controller) }
         composable(account) { AccountScreen(provider, viewModelStoreOwner) }
-        composable(password) { PasswordUpdateScreen(provider) {
-            controller.popBackStack()
-        } }
-        composable(preference) { AddressScreen(provider) {
-            controller.popBackStack()
-        } }
+        composable(password) {
+            PasswordUpdateScreen(provider) {
+                controller.popBackStack()
+            }
+        }
+        composable(preference) {
+            AddressScreen(provider) {
+                controller.popBackStack()
+            }
+        }
+        composable("about_us") {
+            AboutUsScreen()
+        }
     }
 }

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/settings/SettingsScreen.kt
@@ -1,20 +1,15 @@
 package eu.peernetwork.app.ui.settings
 
+import androidx.compose.runtime.remember
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -66,7 +61,10 @@ fun SettingsScreen(
     val handleOnNavigate by rememberUpdatedState(onNavigate)
     val password = stringResource(R.string.password_label)
     val preference = stringResource(R.string.preference_label)
-    Column(modifier = Modifier.fillMaxSize()
+    val aboutUsLabel = stringResource(R.string.about_us_label)
+
+    Column(modifier = Modifier
+        .fillMaxSize()
         .verticalScroll(rememberScrollState())) {
         Box(modifier = Modifier.padding(12.dp)) {
             updateHeader()
@@ -77,6 +75,9 @@ fun SettingsScreen(
         SettingsItem(label = preference) {
             handleOnNavigate(preference)
         }
+        SettingsItem(label = aboutUsLabel) {
+            handleOnNavigate("about_us") // hardcoded route
+        }
     }
 }
 
@@ -85,9 +86,12 @@ fun SettingsScreen(
 fun PreviewSettingsScreen() {
     PeerTheme {
         SettingsScreen({}) {
-            Box(modifier = Modifier.fillMaxWidth()
-                .height(96.dp)
-                .background(MaterialTheme.colorScheme.tertiaryContainer))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(96.dp)
+                    .background(MaterialTheme.colorScheme.tertiaryContainer)
+            )
         }
     }
 }

--- a/user/ui/src/main/res/values/strings.xml
+++ b/user/ui/src/main/res/values/strings.xml
@@ -41,4 +41,12 @@
     <string name="password_reset_instruction">Enter the email associated with your account and we\'ll send an email with instructions to reset your password.</string>
     <string name="password_instruction">We\'ve sent a password recovery token to your email. Please enter the token along with your new password to proceed.</string>
     <string name="password_alternative_question">Already received the token?</string>
+
+    <string name="app_information_label">App Information</string>
+    <string name="about_us_label">About Us</string>
+    <string name="app_name_label">App Name: Peer</string>
+    <string name="version_text_label">Version:</string>
+    <string name="developed_by_label">Developed by: Peer Network Team</string>
+    <string name="copyright_label">© 2024 Peer Network. All rights reserved.</string>
+    <string name="about_us_description_label">The first social platform Returning 96% of ad revenue to creators through blockchain technology.</string>
 </resources>


### PR DESCRIPTION
## This PR adds a new About Us screen accessible from the Settings screen. 

### It includes:
- App version info via BuildConfig
- Descriptive branding text
- UI follows PeerTheme
- App icon centered at the top
