### PR TITLE
feat(feed): implement feed sorting by trend and new on main screen

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedScreen.kt
@@ -8,17 +8,22 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableIntState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,6 +36,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import eu.peernetwork.app.BuildConfig
 import eu.peernetwork.blog.domain.model.Filter.Criteria
+import eu.peernetwork.blog.domain.model.Sort
 import eu.peernetwork.media.core.model.UiMimeType
 import eu.peernetwork.blog.ui.timeline.photo.PhotoScreen
 import eu.peernetwork.blog.ui.timeline.video.VideoScreen
@@ -68,6 +74,13 @@ fun FeedScreen(
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
     val pageState = remember { mutableIntStateOf(state.page) }
+    val sorting = remember { mutableStateOf(Sort.TREND) }
+    val filter = remember {
+        derivedStateOf {
+            (criteria as? Criteria.Content?)?.let { it.copy(sort = sorting.value) }
+                ?: Criteria.Content(sorting.value)
+        }
+    }
     FeedNavigation(
         userId = id,
         postLimit = postLimit,
@@ -89,7 +102,7 @@ fun FeedScreen(
                     PhotoScreen(
                         id,
                         BuildConfig.PAGING_LIMIT,
-                        criteria,
+                        filter.value,
                         { controller.navigateToUsernameSearch(it) },
                         { controller.navigateToTagSearch(it) },
                         component,
@@ -108,7 +121,7 @@ fun FeedScreen(
                     VideoScreen(
                         id,
                         BuildConfig.PAGING_LIMIT,
-                        criteria,
+                        filter.value,
                         { controller.navigateToUsernameSearch(it) },
                         { controller.navigateToTagSearch(it) },
                         component,
@@ -133,12 +146,46 @@ fun FeedScreen(
                     }
                 }
             ) {
+
                 titleBar {
-                    DesignTitle(modifier = Modifier
-                        .clickable(
+                    var dropdownExpanded by remember { mutableStateOf(false) }
+
+                    DesignTitle(
+                        modifier = Modifier.clickable(
                             role = Role.Button,
-                            onClick = {  })) {
+                            onClick = { dropdownExpanded = true }
+                        )
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_caret_down),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .padding(start=62.dp)
+                                .size(20.dp),
+                            tint = MaterialTheme.colorScheme.onSurface
+                        )
                         Text(title ?: stringResource(R.string.feed_label))
+                    }
+
+
+                    DropdownMenu(
+                        expanded = dropdownExpanded,
+                        onDismissRequest = { dropdownExpanded = false }
+                    ) {
+                        DropdownMenuItem(
+                            text = { Text("New") },
+                            onClick = {
+                                sorting.value = Sort.NEW
+                                dropdownExpanded = false
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Trend") },
+                            onClick = {
+                                sorting.value = Sort.TREND
+                                dropdownExpanded = false
+                            }
+                        )
                     }
                 }
             }
@@ -153,11 +200,17 @@ fun FeedScreen(
     onNavigate: (Int) -> Unit = {},
     photo: @Composable () -> Unit,
     video: @Composable () -> Unit,
-) {
+) {  //new add
     val pageState = rememberPagerState(
         pageCount = { UiMimeType.TYPES.size },
         initialPage = state.intValue
     )
+
+    LaunchedEffect(state.intValue) {
+        if (pageState.currentPage != state.intValue) {
+            pageState.scrollToPage(state.intValue)
+        }
+    }
     Column {
         DesignTab(pageState) { index ->
             UiMimeType.get(index)?.let {

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/timeline/photo/PhotoScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/timeline/photo/PhotoScreen.kt
@@ -169,6 +169,9 @@ fun PhotoScreen(
             }
         }
     }
+    LaunchedEffect(criteria) {
+        criteria?.let { viewModel.load(Pageable(0, postLimit), criteria) }
+    }
 }
 
 @Composable

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/timeline/video/VideoScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/timeline/video/VideoScreen.kt
@@ -164,8 +164,13 @@ fun VideoScreen(
             }
         }
         VideoDialog(postLimit, selectedClip, provider, viewModelStoreOwner)
+
+    }
+    LaunchedEffect(criteria) {
+        criteria?.let { viewModel.load(Pageable(0, postLimit), criteria) }
     }
 }
+
 
 @Composable
 fun VideoScreen(


### PR DESCRIPTION
### What's the PR for??

- Implemented dropdown to refresh feeds based on the user's needs `NEW `feeds and `TREND` ing feeds
- Added dropdown arrow icon  next to the title (“Friends”) in the FeedScreen dropdown.
- Tested with both Photo and Video tabs.

### How to Test
1. Open the Feed screen.
2. Switch between "Photo" and "Video" tabs — content should load correctly.
3. Tap the title (“Friends”) — dropdown should open, and icon should appear beside the title.
4. Select a sorting option (“New” / “Trend”) — should update feed accordingly.

