### PR TITLE
feat(user): implement profile avatar full-screen preview with zoom an…

### DIFF
--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignAsyncImage.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignAsyncImage.kt
@@ -2,19 +2,23 @@ package eu.peernetwork.core.ui.design.compose
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,30 +32,26 @@ fun DesignAsyncImage(
     label: String,
     imageUrl: String,
     modifier: Modifier = Modifier,
+    onClick: (String) -> Unit = {},
     size: Dp = 64.dp,
     color: Color = MaterialTheme.colorScheme.tertiaryContainer,
     style: TextStyle = MaterialTheme.typography.titleLarge.copy(
         color = MaterialTheme.colorScheme.tertiary,
         fontWeight = FontWeight.Normal
-    ),
-    onImageLoaded: (Boolean) -> Unit = {}
+    )
 ) {
     val isAvatarLoaded = remember { mutableStateOf(false) }
-
+    val handleClick by rememberUpdatedState(onClick)
     Box(modifier = modifier.size(size).background(color)) {
         AsyncImage(
             model = imageUrl,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize()
+                .clickable(role = Role.Button, enabled = true) {
+                    handleClick(imageUrl)
+                },
             contentScale = ContentScale.Crop,
             contentDescription = null,
-            onSuccess = {
-                isAvatarLoaded.value = true
-                onImageLoaded(true)
-            },
-            onError = {
-                isAvatarLoaded.value = false
-                onImageLoaded(false)
-            }
+            onSuccess = { isAvatarLoaded.value = true }
         )
         Text(
             text = label[0].toString().uppercase(),
@@ -59,13 +59,11 @@ fun DesignAsyncImage(
             modifier = Modifier
                 .align(Alignment.Center)
                 .graphicsLayer {
-                if (isAvatarLoaded.value) alpha = 0f else 1f
-            }
-
+                    if (isAvatarLoaded.value) alpha = 0f else 1f
+                }
         )
     }
 }
-
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignAsyncImage.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignAsyncImage.kt
@@ -33,16 +33,25 @@ fun DesignAsyncImage(
     style: TextStyle = MaterialTheme.typography.titleLarge.copy(
         color = MaterialTheme.colorScheme.tertiary,
         fontWeight = FontWeight.Normal
-    )
+    ),
+    onImageLoaded: (Boolean) -> Unit = {}
 ) {
     val isAvatarLoaded = remember { mutableStateOf(false) }
+
     Box(modifier = modifier.size(size).background(color)) {
         AsyncImage(
             model = imageUrl,
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Crop,
             contentDescription = null,
-            onSuccess = { isAvatarLoaded.value = true }
+            onSuccess = {
+                isAvatarLoaded.value = true
+                onImageLoaded(true)
+            },
+            onError = {
+                isAvatarLoaded.value = false
+                onImageLoaded(false)
+            }
         )
         Text(
             text = label[0].toString().uppercase(),
@@ -50,11 +59,13 @@ fun DesignAsyncImage(
             modifier = Modifier
                 .align(Alignment.Center)
                 .graphicsLayer {
-                    if (isAvatarLoaded.value) alpha = 0f else 1f
-                }
+                if (isAvatarLoaded.value) alpha = 0f else 1f
+            }
+
         )
     }
 }
+
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignImageZoom.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignImageZoom.kt
@@ -1,0 +1,165 @@
+package eu.peernetwork.core.ui.design.compose
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.forEachGesture
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import kotlinx.coroutines.launch
+
+@Composable
+fun DesignImageZoom(
+    imageUrl: MutableState<String?>,
+    onDismiss: () -> Unit = {}
+) {
+    val key = remember { System.currentTimeMillis().toString() }
+    val visible = remember(imageUrl.value) { mutableStateOf(imageUrl.value != null) }
+    DesignDialog(
+        key,
+        visible,
+        onDismiss = onDismiss,
+        onAnimationComplete = {
+            if (!it) {
+                imageUrl.value = null
+            }
+        }
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(imageUrl.value)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .blur(200.dp)
+            )
+            val offsetX = remember { mutableFloatStateOf(0f) }
+            val offsetY = remember { mutableFloatStateOf(0f) }
+            val scale = remember { Animatable(1f) }
+            val scope = rememberCoroutineScope()
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = imageUrl.value,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .offset {
+                            if (scale.value == 1f) {
+                                IntOffset(offsetX.floatValue.toInt(), offsetY.floatValue.toInt())
+                            } else {
+                                IntOffset(0, 0)
+                            }
+                        }
+                        .graphicsLayer {
+                            scaleX = scale.value
+                            scaleY = scale.value
+                            shadowElevation = 19.dp.toPx()
+                            shape = CircleShape
+                            clip = true
+                        }
+                        .pointerInput(Unit) {
+                            forEachGesture {
+                                awaitPointerEventScope {
+                                    var zooming = false
+                                    do {
+                                        val event = awaitPointerEvent()
+                                        val zoomChange = event.calculateZoom()
+                                        val pan = event.calculatePan()
+
+                                        if (zoomChange != 1f) zooming = true
+
+                                        val newScale = (scale.value * zoomChange).coerceIn(1f, 2f)
+                                        scope.launch {
+                                            scale.snapTo(newScale)
+                                        }
+                                        if (scale.value == 1f) {
+                                            offsetX.floatValue += pan.x * 0.6f
+                                            offsetY.floatValue += pan.y * 0.6f
+                                        }
+                                    } while (event.changes.any { it.pressed })
+                                    if (zooming) {
+                                        scope.launch {
+                                            scale.animateTo(
+                                                1f,
+                                                animationSpec = tween(durationMillis = 350)
+                                            )
+                                        }
+                                        scope.launch {
+                                            animate(
+                                                initialValue = offsetX.floatValue,
+                                                targetValue = 0f,
+                                                animationSpec = tween(350)
+                                            ) { value, _ -> offsetX.floatValue = value }
+                                        }
+                                        scope.launch {
+                                            animate(
+                                                initialValue = offsetY.floatValue,
+                                                targetValue = 0f,
+                                                animationSpec = tween(350)
+                                            ) { value, _ -> offsetY.floatValue = value }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .pointerInput(Unit) {
+                            detectDragGestures(
+                                onDragEnd = {
+                                    scope.launch {
+                                        animate(
+                                            initialValue = offsetX.floatValue,
+                                            targetValue = 0f,
+                                            animationSpec = tween(300)
+                                        ) { value, _ -> offsetX.floatValue = value }
+                                    }
+                                    scope.launch {
+                                        animate(
+                                            initialValue = offsetY.floatValue,
+                                            targetValue = 0f,
+                                            animationSpec = tween(300)
+                                        ) { value, _ -> offsetY.floatValue = value }
+                                    }
+                                }
+                            ) { change, dragAmount ->
+                                change.consume()
+                                if (scale.value == 1f) {
+                                    offsetX.floatValue += dragAmount.x * 0.6f
+                                    offsetY.floatValue += dragAmount.y * 0.6f
+                                }
+                            }
+                        }.size(240.dp)
+                )
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ blur = "1.0.7"
 media3 = "1.6.1"
 lrucache = "2.0.2"
 lottie = "6.6.6"
-accompanist = "0.34.0"
 
 [libraries]
 androidx-splash = { module = "androidx.core:core-splashscreen", version.ref = "androidx-splash" }
@@ -85,9 +84,6 @@ mockk-jvm = { module = "io.mockk:mockk-jvm", version.ref = "mockk-jvm" }
 permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "permissions" }
 blur = { module = "com.github.Commit451:NativeStackBlur", version.ref = "blur" }
 lottie = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie" }
-accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
-
-
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ blur = "1.0.7"
 media3 = "1.6.1"
 lrucache = "2.0.2"
 lottie = "6.6.6"
+accompanist = "0.34.0"
 
 [libraries]
 androidx-splash = { module = "androidx.core:core-splashscreen", version.ref = "androidx-splash" }
@@ -84,6 +85,9 @@ mockk-jvm = { module = "io.mockk:mockk-jvm", version.ref = "mockk-jvm" }
 permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "permissions" }
 blur = { module = "com.github.Commit451:NativeStackBlur", version.ref = "blur" }
 lottie = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie" }
+accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
+
+
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/user/ui/build.gradle.kts
+++ b/user/ui/build.gradle.kts
@@ -15,10 +15,7 @@ dependencies {
 
     implementation(project(":user:domain"))
 
-    implementation(libs.accompanist.systemuicontroller)
-
     implementation(libs.ucrop)
-
     implementation(libs.dagger)
     ksp(libs.dagger.compiler)
 

--- a/user/ui/build.gradle.kts
+++ b/user/ui/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
 
     implementation(project(":user:domain"))
 
+    implementation(libs.accompanist.systemuicontroller)
+
     implementation(libs.ucrop)
 
     implementation(libs.dagger)

--- a/user/ui/src/main/kotlin/eu/peernetwork/user/ui/user/UserScreen.kt
+++ b/user/ui/src/main/kotlin/eu/peernetwork/user/ui/user/UserScreen.kt
@@ -1,42 +1,65 @@
 package eu.peernetwork.user.ui.user
 
 import android.content.res.Configuration
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.*
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import eu.peernetwork.core.ui.component.UiComponentProvider
-import eu.peernetwork.core.ui.extension.builder
-import eu.peernetwork.core.ui.theme.PeerTheme
-import eu.peernetwork.user.ui.model.UiAccount
-import eu.peernetwork.user.ui.model.UiOverview
-import eu.peernetwork.core.ui.design.compose.DesignAsyncImage
 import eu.peernetwork.core.ui.design.component.DesignStatefulScaffold
 import eu.peernetwork.core.ui.design.component.DesignStatefulScaffoldState
+import eu.peernetwork.core.ui.design.compose.DesignAsyncImage
 import eu.peernetwork.core.ui.design.compose.DesignLead
+import eu.peernetwork.core.ui.extension.builder
 import eu.peernetwork.core.ui.extension.toInt
+import eu.peernetwork.core.ui.theme.PeerTheme
 import eu.peernetwork.user.ui.R
 import eu.peernetwork.user.ui.compose.Overview
 import eu.peernetwork.user.ui.compose.ProfileScaffold
+import eu.peernetwork.user.ui.model.UiAccount
+import eu.peernetwork.user.ui.model.UiOverview
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.*
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.window.DialogProperties
+import coil.request.ImageRequest
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.animate
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
+import androidx.compose.foundation.gestures.forEachGesture
+import kotlinx.coroutines.launch
 
 @Composable
 fun UserScreen(
@@ -59,24 +82,27 @@ fun UserScreen(
         factory = component.viewModelFactory()
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val derivedState = remember(state) { derivedStateOf {
-        when(state) {
-            UserViewModel.State.Empty -> DesignStatefulScaffoldState.Empty
-            UserViewModel.State.Loading -> DesignStatefulScaffoldState.Loading
-            is UserViewModel.State.Success -> {
-                DesignStatefulScaffoldState.Success(
-                    (state as UserViewModel.State.Success).let {
-                        Pair(it.account, it.configurable)
-                    }
-                )
-            }
-            is UserViewModel.State.Error -> {
-                DesignStatefulScaffoldState.Error(
-                    (state as UserViewModel.State.Error).error
-                )
+    val derivedState = remember(state) {
+        derivedStateOf {
+            when (state) {
+                UserViewModel.State.Empty -> DesignStatefulScaffoldState.Empty
+                UserViewModel.State.Loading -> DesignStatefulScaffoldState.Loading
+                is UserViewModel.State.Success -> {
+                    DesignStatefulScaffoldState.Success(
+                        (state as UserViewModel.State.Success).let {
+                            Pair(it.account, it.configurable)
+                        }
+                    )
+                }
+
+                is UserViewModel.State.Error -> {
+                    DesignStatefulScaffoldState.Error(
+                        (state as UserViewModel.State.Error).error
+                    )
+                }
             }
         }
-    } }
+    }
     val updatedAt = remember { mutableLongStateOf(lastUpdated.value) }
     DesignStatefulScaffold<Pair<UiAccount, Boolean>>(
         state = derivedState,
@@ -118,10 +144,29 @@ fun UserScreen(
     val clickHandler by rememberUpdatedState(onClick)
     val settingsHandler by rememberUpdatedState(onSettings)
     val updatedConnection by rememberUpdatedState(connection)
-    val emptyDescription = stringResource(R.string.empty_description_message)
+
+    val showImageDialog = remember { mutableStateOf(false) }
+
     ProfileScaffold(
         modifier = modifier,
-        avatar = { DesignAsyncImage(account.username, account.imageUrl) },
+        avatar = {
+            val isImageLoaded = remember { mutableStateOf(false) }
+
+            val avatarModifier = if (isImageLoaded.value) {
+                Modifier.clickable { showImageDialog.value = true }
+            } else {
+                Modifier
+            }
+
+            DesignAsyncImage(
+                label = account.username,
+                imageUrl = account.imageUrl,
+                modifier = avatarModifier,
+                onImageLoaded = { loaded ->
+                    isImageLoaded.value = loaded
+                }
+            )
+        },
         actions = {
             if (settingsHandler != null) {
                 IconButton(onClick = { settingsHandler?.invoke() }) {
@@ -133,9 +178,12 @@ fun UserScreen(
                 }
             } else {
                 Box(
-                    modifier = Modifier.padding(vertical = 8.dp)
+                    modifier = Modifier
+                        .padding(vertical = 8.dp)
                         .padding(bottom = 4.dp)
-                ) { updatedConnection(account.isfollowing to account.isfollowed) }
+                ) {
+                    updatedConnection(account.isfollowing to account.isfollowed)
+                }
             }
         },
         options = {
@@ -149,10 +197,222 @@ fun UserScreen(
         DesignLead(
             account.username,
             account.slug.toString(),
-            account.bio ?: emptyDescription
+            account.bio ?: stringResource(R.string.empty_description_message)
+
+        )
+    }
+
+    if (showImageDialog.value) {
+        FullScreenImageDialogDarkBlur(
+            imageUrl = account.imageUrl,
+            onDismiss = { showImageDialog.value = false }
         )
     }
 }
+
+@OptIn(ExperimentalAnimationApi::class)
+@Suppress("DEPRECATION")
+
+@Composable
+fun FullScreenImageDialogDarkBlur(
+    imageUrl: String,
+    onDismiss: () -> Unit
+) {
+    var visible by remember { mutableStateOf(false) }
+    var shouldDismiss by remember { mutableStateOf(false) }
+
+    val loadFailed = remember { mutableStateOf(false) }
+    val systemUiController = rememberSystemUiController()
+
+    LaunchedEffect(Unit) {
+        visible = true
+        systemUiController.isNavigationBarVisible = false
+        systemUiController.isStatusBarVisible = true
+    }
+
+
+    LaunchedEffect(loadFailed.value) {
+        if (loadFailed.value) {
+            visible = false
+            systemUiController.isSystemBarsVisible = true
+            onDismiss()
+        }
+    }
+
+    LaunchedEffect(shouldDismiss) {
+        if (shouldDismiss) {
+            visible = false
+            kotlinx.coroutines.delay(300)
+            systemUiController.isSystemBarsVisible = true
+            onDismiss()
+        }
+    }
+
+    Dialog(
+        onDismissRequest = { shouldDismiss = true },
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Transparent)
+        ) {
+            AnimatedVisibility(
+                visible = visible,
+                enter = scaleIn(
+                    initialScale = 0.7f,
+                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
+                ) + fadeIn(
+                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
+                ),
+                exit = scaleOut(
+                    targetScale = 0.7f,
+                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
+                ) + fadeOut(
+                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
+                )
+            ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(imageUrl)
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .blur(200.dp),
+                        onError = {
+                            loadFailed.value = true
+                        },
+                        onSuccess = {
+                            loadFailed.value = false
+                        }
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = 0.75f))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable { shouldDismiss = true }
+                    )
+                    val offsetX = remember { mutableFloatStateOf(0f) }
+                    val offsetY = remember { mutableFloatStateOf(0f) }
+                    val scale = remember { Animatable(1f) }
+                    val scope = rememberCoroutineScope()
+
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        AsyncImage(
+                            model = imageUrl,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .offset {
+                                    if (scale.value == 1f) {
+                                        IntOffset(offsetX.floatValue.toInt(), offsetY.floatValue.toInt())
+                                    } else {
+                                        IntOffset(0, 0)
+                                    }
+                                }
+                                .graphicsLayer {
+                                    scaleX = scale.value
+                                    scaleY = scale.value
+                                    shadowElevation = 19.dp.toPx()
+                                    shape = CircleShape
+                                    clip = true
+                                }
+                                .pointerInput(Unit) {
+                                    forEachGesture {
+                                        awaitPointerEventScope {
+                                            var zooming = false
+                                            do {
+                                                val event = awaitPointerEvent()
+                                                val zoomChange = event.calculateZoom()
+                                                val pan = event.calculatePan()
+
+                                                if (zoomChange != 1f) zooming = true
+
+                                                val newScale = (scale.value * zoomChange).coerceIn(1f, 2f)
+                                                scope.launch {
+                                                    scale.snapTo(newScale)
+                                                }
+                                                if (scale.value == 1f) {
+                                                    offsetX.floatValue += pan.x * 0.6f
+                                                    offsetY.floatValue += pan.y * 0.6f
+                                                }
+                                            } while (event.changes.any { it.pressed })
+
+                                            if (zooming) {
+                                                scope.launch {
+                                                    scale.animateTo(
+                                                        1f,
+                                                        animationSpec = tween(durationMillis = 350)
+                                                    )
+                                                }
+                                                scope.launch {
+                                                    animate(
+                                                        initialValue = offsetX.floatValue,
+                                                        targetValue = 0f,
+                                                        animationSpec = tween(350)
+                                                    ) { value, _ -> offsetX.floatValue = value }
+                                                }
+                                                scope.launch {
+                                                    animate(
+                                                        initialValue = offsetY.floatValue,
+                                                        targetValue = 0f,
+                                                        animationSpec = tween(350)
+                                                    ) { value, _ -> offsetY.floatValue = value }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                .pointerInput(Unit) {
+                                    detectDragGestures(
+                                        onDragEnd = {
+                                            scope.launch {
+                                                animate(
+                                                    initialValue = offsetX.floatValue,
+                                                    targetValue = 0f,
+                                                    animationSpec = tween(300)
+                                                ) { value, _ -> offsetX.floatValue = value }
+                                            }
+                                            scope.launch {
+                                                animate(
+                                                    initialValue = offsetY.floatValue,
+                                                    targetValue = 0f,
+                                                    animationSpec = tween(300)
+                                                ) { value, _ -> offsetY.floatValue = value }
+                                            }
+                                        }
+                                    ) { change, dragAmount ->
+                                        change.consume()
+
+                                        if (scale.value == 1f) {
+                                            offsetX.floatValue += dragAmount.x * 0.6f
+                                            offsetY.floatValue += dragAmount.y * 0.6f
+                                        }
+                                    }
+                                }
+                                .size(240.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/user/ui/src/main/kotlin/eu/peernetwork/user/ui/user/UserScreen.kt
+++ b/user/ui/src/main/kotlin/eu/peernetwork/user/ui/user/UserScreen.kt
@@ -1,65 +1,44 @@
 package eu.peernetwork.user.ui.user
 
 import android.content.res.Configuration
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.runtime.*
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import coil.compose.AsyncImage
 import eu.peernetwork.core.ui.component.UiComponentProvider
+import eu.peernetwork.core.ui.extension.builder
+import eu.peernetwork.core.ui.theme.PeerTheme
+import eu.peernetwork.user.ui.model.UiAccount
+import eu.peernetwork.user.ui.model.UiOverview
+import eu.peernetwork.core.ui.design.compose.DesignAsyncImage
 import eu.peernetwork.core.ui.design.component.DesignStatefulScaffold
 import eu.peernetwork.core.ui.design.component.DesignStatefulScaffoldState
-import eu.peernetwork.core.ui.design.compose.DesignAsyncImage
+import eu.peernetwork.core.ui.design.compose.DesignImageZoom
 import eu.peernetwork.core.ui.design.compose.DesignLead
-import eu.peernetwork.core.ui.extension.builder
 import eu.peernetwork.core.ui.extension.toInt
-import eu.peernetwork.core.ui.theme.PeerTheme
 import eu.peernetwork.user.ui.R
 import eu.peernetwork.user.ui.compose.Overview
 import eu.peernetwork.user.ui.compose.ProfileScaffold
-import eu.peernetwork.user.ui.model.UiAccount
-import eu.peernetwork.user.ui.model.UiOverview
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
-import androidx.compose.animation.*
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.window.DialogProperties
-import coil.request.ImageRequest
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.animate
-import androidx.compose.foundation.gestures.calculatePan
-import androidx.compose.foundation.gestures.calculateZoom
-import androidx.compose.foundation.gestures.forEachGesture
-import kotlinx.coroutines.launch
 
 @Composable
 fun UserScreen(
@@ -82,27 +61,24 @@ fun UserScreen(
         factory = component.viewModelFactory()
     )
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val derivedState = remember(state) {
-        derivedStateOf {
-            when (state) {
-                UserViewModel.State.Empty -> DesignStatefulScaffoldState.Empty
-                UserViewModel.State.Loading -> DesignStatefulScaffoldState.Loading
-                is UserViewModel.State.Success -> {
-                    DesignStatefulScaffoldState.Success(
-                        (state as UserViewModel.State.Success).let {
-                            Pair(it.account, it.configurable)
-                        }
-                    )
-                }
-
-                is UserViewModel.State.Error -> {
-                    DesignStatefulScaffoldState.Error(
-                        (state as UserViewModel.State.Error).error
-                    )
-                }
+    val derivedState = remember(state) { derivedStateOf {
+        when(state) {
+            UserViewModel.State.Empty -> DesignStatefulScaffoldState.Empty
+            UserViewModel.State.Loading -> DesignStatefulScaffoldState.Loading
+            is UserViewModel.State.Success -> {
+                DesignStatefulScaffoldState.Success(
+                    (state as UserViewModel.State.Success).let {
+                        Pair(it.account, it.configurable)
+                    }
+                )
+            }
+            is UserViewModel.State.Error -> {
+                DesignStatefulScaffoldState.Error(
+                    (state as UserViewModel.State.Error).error
+                )
             }
         }
-    }
+    } }
     val updatedAt = remember { mutableLongStateOf(lastUpdated.value) }
     DesignStatefulScaffold<Pair<UiAccount, Boolean>>(
         state = derivedState,
@@ -143,30 +119,14 @@ fun UserScreen(
 ) {
     val clickHandler by rememberUpdatedState(onClick)
     val settingsHandler by rememberUpdatedState(onSettings)
+    val selectedImage = remember { mutableStateOf<String?>(null) }
     val updatedConnection by rememberUpdatedState(connection)
-
-    val showImageDialog = remember { mutableStateOf(false) }
-
+    val emptyDescription = stringResource(R.string.empty_description_message)
     ProfileScaffold(
         modifier = modifier,
-        avatar = {
-            val isImageLoaded = remember { mutableStateOf(false) }
-
-            val avatarModifier = if (isImageLoaded.value) {
-                Modifier.clickable { showImageDialog.value = true }
-            } else {
-                Modifier
-            }
-
-            DesignAsyncImage(
-                label = account.username,
-                imageUrl = account.imageUrl,
-                modifier = avatarModifier,
-                onImageLoaded = { loaded ->
-                    isImageLoaded.value = loaded
-                }
-            )
-        },
+        avatar = { DesignAsyncImage(account.username, account.imageUrl, onClick = {
+            selectedImage.value = it
+        }) },
         actions = {
             if (settingsHandler != null) {
                 IconButton(onClick = { settingsHandler?.invoke() }) {
@@ -178,12 +138,9 @@ fun UserScreen(
                 }
             } else {
                 Box(
-                    modifier = Modifier
-                        .padding(vertical = 8.dp)
+                    modifier = Modifier.padding(vertical = 8.dp)
                         .padding(bottom = 4.dp)
-                ) {
-                    updatedConnection(account.isfollowing to account.isfollowed)
-                }
+                ) { updatedConnection(account.isfollowing to account.isfollowed) }
             }
         },
         options = {
@@ -197,222 +154,11 @@ fun UserScreen(
         DesignLead(
             account.username,
             account.slug.toString(),
-            account.bio ?: stringResource(R.string.empty_description_message)
-
+            account.bio ?: emptyDescription
         )
     }
-
-    if (showImageDialog.value) {
-        FullScreenImageDialogDarkBlur(
-            imageUrl = account.imageUrl,
-            onDismiss = { showImageDialog.value = false }
-        )
-    }
+    DesignImageZoom(selectedImage)
 }
-
-@OptIn(ExperimentalAnimationApi::class)
-@Suppress("DEPRECATION")
-
-@Composable
-fun FullScreenImageDialogDarkBlur(
-    imageUrl: String,
-    onDismiss: () -> Unit
-) {
-    var visible by remember { mutableStateOf(false) }
-    var shouldDismiss by remember { mutableStateOf(false) }
-
-    val loadFailed = remember { mutableStateOf(false) }
-    val systemUiController = rememberSystemUiController()
-
-    LaunchedEffect(Unit) {
-        visible = true
-        systemUiController.isNavigationBarVisible = false
-        systemUiController.isStatusBarVisible = true
-    }
-
-
-    LaunchedEffect(loadFailed.value) {
-        if (loadFailed.value) {
-            visible = false
-            systemUiController.isSystemBarsVisible = true
-            onDismiss()
-        }
-    }
-
-    LaunchedEffect(shouldDismiss) {
-        if (shouldDismiss) {
-            visible = false
-            kotlinx.coroutines.delay(300)
-            systemUiController.isSystemBarsVisible = true
-            onDismiss()
-        }
-    }
-
-    Dialog(
-        onDismissRequest = { shouldDismiss = true },
-        properties = DialogProperties(
-            usePlatformDefaultWidth = false,
-            decorFitsSystemWindows = false
-        )
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Transparent)
-        ) {
-            AnimatedVisibility(
-                visible = visible,
-                enter = scaleIn(
-                    initialScale = 0.7f,
-                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
-                ) + fadeIn(
-                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
-                ),
-                exit = scaleOut(
-                    targetScale = 0.7f,
-                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
-                ) + fadeOut(
-                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing)
-                )
-            ) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data(imageUrl)
-                            .crossfade(true)
-                            .build(),
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .blur(200.dp),
-                        onError = {
-                            loadFailed.value = true
-                        },
-                        onSuccess = {
-                            loadFailed.value = false
-                        }
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(Color.Black.copy(alpha = 0.75f))
-                    )
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clickable { shouldDismiss = true }
-                    )
-                    val offsetX = remember { mutableFloatStateOf(0f) }
-                    val offsetY = remember { mutableFloatStateOf(0f) }
-                    val scale = remember { Animatable(1f) }
-                    val scope = rememberCoroutineScope()
-
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        AsyncImage(
-                            model = imageUrl,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .offset {
-                                    if (scale.value == 1f) {
-                                        IntOffset(offsetX.floatValue.toInt(), offsetY.floatValue.toInt())
-                                    } else {
-                                        IntOffset(0, 0)
-                                    }
-                                }
-                                .graphicsLayer {
-                                    scaleX = scale.value
-                                    scaleY = scale.value
-                                    shadowElevation = 19.dp.toPx()
-                                    shape = CircleShape
-                                    clip = true
-                                }
-                                .pointerInput(Unit) {
-                                    forEachGesture {
-                                        awaitPointerEventScope {
-                                            var zooming = false
-                                            do {
-                                                val event = awaitPointerEvent()
-                                                val zoomChange = event.calculateZoom()
-                                                val pan = event.calculatePan()
-
-                                                if (zoomChange != 1f) zooming = true
-
-                                                val newScale = (scale.value * zoomChange).coerceIn(1f, 2f)
-                                                scope.launch {
-                                                    scale.snapTo(newScale)
-                                                }
-                                                if (scale.value == 1f) {
-                                                    offsetX.floatValue += pan.x * 0.6f
-                                                    offsetY.floatValue += pan.y * 0.6f
-                                                }
-                                            } while (event.changes.any { it.pressed })
-
-                                            if (zooming) {
-                                                scope.launch {
-                                                    scale.animateTo(
-                                                        1f,
-                                                        animationSpec = tween(durationMillis = 350)
-                                                    )
-                                                }
-                                                scope.launch {
-                                                    animate(
-                                                        initialValue = offsetX.floatValue,
-                                                        targetValue = 0f,
-                                                        animationSpec = tween(350)
-                                                    ) { value, _ -> offsetX.floatValue = value }
-                                                }
-                                                scope.launch {
-                                                    animate(
-                                                        initialValue = offsetY.floatValue,
-                                                        targetValue = 0f,
-                                                        animationSpec = tween(350)
-                                                    ) { value, _ -> offsetY.floatValue = value }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                .pointerInput(Unit) {
-                                    detectDragGestures(
-                                        onDragEnd = {
-                                            scope.launch {
-                                                animate(
-                                                    initialValue = offsetX.floatValue,
-                                                    targetValue = 0f,
-                                                    animationSpec = tween(300)
-                                                ) { value, _ -> offsetX.floatValue = value }
-                                            }
-                                            scope.launch {
-                                                animate(
-                                                    initialValue = offsetY.floatValue,
-                                                    targetValue = 0f,
-                                                    animationSpec = tween(300)
-                                                ) { value, _ -> offsetY.floatValue = value }
-                                            }
-                                        }
-                                    ) { change, dragAmount ->
-                                        change.consume()
-
-                                        if (scale.value == 1f) {
-                                            offsetX.floatValue += dragAmount.x * 0.6f
-                                            offsetY.floatValue += dragAmount.y * 0.6f
-                                        }
-                                    }
-                                }
-                                .size(240.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)


### PR DESCRIPTION
## 📌 Background
Users should be able to preview their profile avatar in full size when tapping on it. This improves the user experience by allowing them to see their profile picture in greater detail and lays the groundwork for future zooming or editing enhancements.

## 🎯 Goal

- When a user is viewing their own profile, tapping the avatar should open a full-screen preview.
- The preview displays the current avatar image in high resolution.
- The user can dismiss the preview by tapping outside or using the back gesture.
- Prevents dialog from opening if no avatar is set or load fails.
- User can dismiss with a tap or back gesture.

## 🧪 Testing
✅ Verified on device
✅ Profile without avatar does not open dialog
✅ Smooth open/close transitions
✅ Avatar image zoom and pan works as expected
✅ No crashes

## 🧹 Cleanup

- Removed unnecessary lines and redundant codes
- Removed Debug logs
- Removed Comments which was used for personal reference