### PR TITLE
feat(explorer): create edit icon and navigate to VideoScreen on edit …

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerNavigation.kt
@@ -3,12 +3,18 @@ package eu.peernetwork.app.ui.composer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import eu.peernetwork.core.ui.component.UiComponentProvider
 import eu.peernetwork.core.ui.design.compose.DesignRouter
+import eu.peernetwork.core.ui.extension.navigateIfNecessary
+import eu.peernetwork.core.ui.model.ViewModelState
 import eu.peernetwork.media.core.model.UiAttachment
+import eu.peernetwork.media.core.model.UiMimeType
+import eu.peernetwork.media.ui.editor.video.VideoScreen
 import eu.peernetwork.media.ui.selector.explorer.ExplorerScreen
 
 @Composable
@@ -19,14 +25,31 @@ fun ComposerNavigation(
     content: @Composable () -> Unit
 ) {
     val updatedContent by rememberUpdatedState(content)
+    val viewModelStore = remember { ViewModelState() }  // share ViewModelStore here
+
     DesignRouter(
         navController = controller,
         startDestination = "editor"
     ) {
         composable("editor") { updatedContent() }
+        composable("video") { backStackEntry ->
+            val type = UiMimeType.Video
+            val directory = remember { mutableStateOf<String?>(null) }
+
+            VideoScreen(
+                type = type,
+                directory = directory,
+                attachment = attachment,
+                provider = provider,
+                viewModelStoreOwner = backStackEntry,
+                isEdit = true
+            )
+        }
+
         composable("explorer") {
             ExplorerScreen(
                 attachment = attachment,
+                onEdit = { controller.navigateIfNecessary("video") },
                 onFinish = { controller.popBackStack() },
                 provider = provider,
             )

--- a/media/ui/src/main/kotlin/eu/peernetwork/media/ui/editor/video/VideoScreen.kt
+++ b/media/ui/src/main/kotlin/eu/peernetwork/media/ui/editor/video/VideoScreen.kt
@@ -1,0 +1,25 @@
+package eu.peernetwork.media.ui.editor.video
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.lifecycle.ViewModelStoreOwner
+import eu.peernetwork.core.ui.component.UiComponentProvider
+import eu.peernetwork.media.core.model.UiAttachment
+import eu.peernetwork.media.core.model.UiMimeType
+
+@Composable
+fun VideoScreen(
+    type: UiMimeType,
+    directory: MutableState<String?>,
+    attachment: MutableState<UiAttachment>,
+    provider: UiComponentProvider,
+    viewModelStoreOwner: ViewModelStoreOwner,
+    isEdit: Boolean = false
+) {
+    if (isEdit) {
+
+        println("EDIT MODE ON!")
+    }
+
+
+}

--- a/media/ui/src/main/kotlin/eu/peernetwork/media/ui/selector/explorer/ExplorerScreen.kt
+++ b/media/ui/src/main/kotlin/eu/peernetwork/media/ui/selector/explorer/ExplorerScreen.kt
@@ -53,11 +53,15 @@ import eu.peernetwork.media.ui.R
 import eu.peernetwork.media.ui.selector.directory.DirectoryScreen
 import eu.peernetwork.media.ui.selector.photo.PhotoScreen
 import eu.peernetwork.media.ui.selector.video.VideoScreen
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.ui.res.painterResource
 
 @Composable
 @OptIn(ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class)
 fun ExplorerScreen(
     attachment: MutableState<UiAttachment>,
+    onEdit: () -> Unit,
     onFinish: () -> Unit,
     provider: UiComponentProvider
 ) {
@@ -71,6 +75,7 @@ fun ExplorerScreen(
     ExplorerScreen(
         title = title,
         onFinish = onFinish,
+        onEdit = onEdit,
         attachment = attachment,
         onClick = { showDirectory.value = true },
         onSelect = {
@@ -78,6 +83,7 @@ fun ExplorerScreen(
             attachment.value = UiAttachment.File(it, emptyList()) },
     ) { type ->
         val tag = directory.value ?: type.id.toString()
+        val viewModelStore = remember { ViewModelState() }
         when(type) {
             UiMimeType.Video -> VideoScreen(
                 type = type,
@@ -129,6 +135,7 @@ fun ExplorerScreen(
     title: MutableState<String>,
     attachment: MutableState<UiAttachment>,
     onClick: () -> Unit,
+    onEdit: () -> Unit,
     onFinish: () -> Unit,
     onSelect: (UiMimeType) -> Unit,
     content: @Composable (UiMimeType) -> Unit
@@ -151,18 +158,18 @@ fun ExplorerScreen(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-            .fillMaxWidth()
-            .drawBehind {
-                val strokeWidth = 1.dp.toPx()
-                val y = size.height - strokeWidth / 2
-                drawLine(
-                    color = border,
-                    start = Offset(0f, y),
-                    end = Offset(size.width, y),
-                    strokeWidth = strokeWidth
-                )
-            }
-            .padding(vertical = 12.dp, horizontal = 24.dp)) {
+                .fillMaxWidth()
+                .drawBehind {
+                    val strokeWidth = 1.dp.toPx()
+                    val y = size.height - strokeWidth / 2
+                    drawLine(
+                        color = border,
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = strokeWidth
+                    )
+                }
+                .padding(vertical = 12.dp, horizontal = 24.dp)) {
             DesignDropDown(
                 expanded,
                 default = title.value,
@@ -215,8 +222,8 @@ fun ExplorerScreen(
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier.size(28.dp)
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(MaterialTheme.colorScheme.onBackground)
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(MaterialTheme.colorScheme.onBackground)
                 ) {
                     Text(
                         "${attachment.value.files.size}",
@@ -227,6 +234,26 @@ fun ExplorerScreen(
                     )
                 }
             }
+            Spacer(modifier = Modifier.width(8.dp))
+
+            if (attachment.value.files.isNotEmpty() && type.value == UiMimeType.Video && !expanded.value) {
+                IconButton(
+                    onClick = { onEdit() },
+                    modifier = Modifier
+                        .size(32.dp) // Smaller size
+                        .padding(end = 7.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(eu.peernetwork.core.ui.R.drawable.ic_edit),
+                        contentDescription = "Edit",
+                        tint = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+            }
+
+
             Spacer(modifier = Modifier.width(8.dp))
             DesignOutlinedButton(
                 onClick = onFinish,
@@ -261,6 +288,7 @@ fun PreviewExplorerScreen() {
         ExplorerScreen(
             remember { mutableStateOf(photo) },
             remember { mutableStateOf(UiAttachment.Text) },
+            {},
             {},
             {},
             {}


### PR DESCRIPTION
📌 Summary
This PR implements navigation from the ExplorerScreen to the VideoScreen (in editor package) when the user taps the edit icon for video files.

🛠 Changes Made

- Added Icon button
- Added onEdit callback parameter to the inner ExplorerScreen function.
- Hooked up the edit icon (IconButton) to trigger onEdit() when UiMimeType.Video and attachment is present.
- Passed onEdit from the outer ExplorerScreen to the inner ExplorerScreen.
- In ComposerNavigation, routed onEdit to navigate to the video screen.
- Ensured correct ViewModelStoreOwner is used via backStackEntry.

🧪 Test Cases
✅ Open media selector and choose a video → Edit icon becomes visible.
✅ Tapping edit icon navigates to VideoScreen.

