### PR TITLE
fix: correct back navigation behavior on HomeScreen for all feed screens

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeFooter.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeFooter.kt
@@ -1,6 +1,7 @@
 package eu.peernetwork.app.ui.home
 
 import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,8 +12,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -26,12 +29,12 @@ import eu.peernetwork.core.ui.theme.PeerTheme
 
 @Composable
 fun HomeFooter(
-    start: Int,
+    start: State<Int>,
     modifier: Modifier = Modifier,
     onClick: (Int, Int) -> Unit,
 ) {
     val handleClick by rememberUpdatedState(onClick)
-    val state = rememberSaveable { mutableIntStateOf(start) }
+    val state = rememberSaveable(start.value) { mutableIntStateOf(start.value) }
     Box(modifier = Modifier
         .fillMaxWidth()
         .background(MaterialTheme.colorScheme.background)
@@ -69,12 +72,16 @@ fun HomeFooter(
             }
         }
     }
+    BackHandler(enabled = state.intValue != 0) {
+        handleClick(state.intValue, 0)
+        state.intValue = 0
+    }
 }
 
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 fun PreviewHomeBottomBar() {
     PeerTheme {
-        HomeFooter(start = 0) { prev, next -> }
+        HomeFooter(start = remember { mutableIntStateOf(0) }) { prev, next -> }
     }
 }

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
@@ -1,8 +1,6 @@
 package eu.peernetwork.app.ui.home
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import eu.peernetwork.app.BuildConfig

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeScaffold.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeScaffold.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,7 +35,7 @@ fun PreviewHomeScaffold() {
     PeerTheme {
         HomeScaffold(
             header = {  },
-            footer = { HomeFooter(0) { prev, next -> } }
+            footer = { HomeFooter(remember { mutableIntStateOf(0) }) { prev, next -> } }
         ) { state ->
             Text(
                 text = "",

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeScreen.kt
@@ -66,7 +66,7 @@ fun HomeScreen(provider: UiComponentProvider) {
         val navigationState = rememberSaveable { mutableIntStateOf(data.second) }
         val startDestination = remember { HomeRoute.get(navigationState.intValue).path }
         HomeScreen(
-            start = data.second,
+            start = navigationState,
             options = { RewardScreen(component, viewModelStore.get(data.first)) },
             onClick = {
                 viewModel.lastVisited(it)
@@ -87,7 +87,7 @@ fun HomeScreen(provider: UiComponentProvider) {
 
 @Composable
 fun HomeScreen(
-    start: Int,
+    start: State<Int>,
     options: @Composable () -> Unit,
     onClick: (Int) -> Unit,
     content: @Composable (State<Float>) -> Unit
@@ -117,7 +117,7 @@ fun HomeScreen(
 fun PreviewHomeScreen() {
     PeerTheme {
         HomeScreen(
-            start = 0,
+            start = remember { mutableIntStateOf(0) },
             options = {},
             onClick = {},
         ) { state ->


### PR DESCRIPTION
# 🎯 Fixes issue where pressing back on the app, sudden app exists

## 🔧 Behavior:
- When on the Home tab (index 0), back press is now handled by the system (app exits naturally and smoothly)
- When on other tabs, back press returns user to the Home tab instead of exiting the app.

