### PR TITLE
feat(navigation): navigate to home after post and fix video back pres…

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerScreen.kt
@@ -37,7 +37,8 @@ import kotlinx.coroutines.FlowPreview
 @OptIn(FlowPreview::class)
 fun ComposerScreen(
     provider: UiComponentProvider,
-    viewModelStore: ViewModelState
+    viewModelStore: ViewModelState,
+    onPostSuccess: () -> Unit
 ) {
     val context = LocalContext.current
     val component = remember {
@@ -63,11 +64,12 @@ fun ComposerScreen(
             )
         }) {
             CreatorScreen(
-                draft,
-                attachment,
-                focus,
-                component,
-                viewModelStore.get(key)
+                draft = draft,
+                attachment = attachment,
+                focus = focus,
+                provider = component,
+                viewModelStoreOwner = viewModelStore.get(key),
+                onSuccess = onPostSuccess
             )
             DesignTitleBarHost("CreatorScreen") {
                 titleBar {

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
@@ -1,26 +1,19 @@
 package eu.peernetwork.app.ui.feed
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableIntState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -59,26 +52,41 @@ fun FeedPreview(
     onAuthorClick: (String) -> Unit = {},
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
-    onPhotoClick: (String, Int) -> Unit = { id, position -> },
-    onVideoClick: (String, Int) -> Unit = { id, position -> },
+    onPhotoClick: (String, Int) -> Unit = { _, _ -> },
+    onVideoClick: (String, Int) -> Unit = { _, _ -> },
 ) {
     val photoState = rememberLazyListState()
     val videoState = rememberLazyListState()
     val coroutine = rememberCoroutineScope()
     val connection by connectionController.observe().collectAsStateWithLifecycle()
     var relation by rememberSaveable {
-        mutableStateOf<Relation>(Relation.entries.getOrNull(ordinal)
-            ?: Relation.NONE)
+        mutableStateOf(Relation.entries.getOrNull(ordinal) ?: Relation.NONE)
     }
     var position by remember { mutableIntStateOf(state.intValue) }
     val handleOnNavigate by rememberUpdatedState(onNavigate)
     val handleOnFilter by rememberUpdatedState(onFilter)
+
+    val pageState = rememberPagerState(
+        pageCount = { UiMimeType.TYPES.size },
+        initialPage = state.intValue
+    )
+
+    BackHandler(enabled = pageState.currentPage == 1) {
+        coroutine.launch {
+            pageState.animateScrollToPage(0)
+        }
+        state.intValue = 0
+        handleOnNavigate(0)
+    }
+
     FeedPreview(
         state = state,
+        pageState = pageState,
         modifier = Modifier.fillMaxSize(),
         onNavigate = {
             position = it
-            handleOnNavigate(it) },
+            handleOnNavigate(it)
+        },
         photo = {
             PhotoScreen(
                 id,
@@ -122,13 +130,15 @@ fun FeedPreview(
             }
         },
     )
+
     FeedMenu(
         id,
         title,
         relation,
         {
             handleOnFilter(it.ordinal)
-            relation = it }
+            relation = it
+        }
     ) {
         coroutine.launch {
             if (position == 0) {
@@ -143,16 +153,14 @@ fun FeedPreview(
 @Composable
 fun FeedPreview(
     state: MutableIntState,
+    pageState: PagerState,
     modifier: Modifier = Modifier,
     onNavigate: (Int) -> Unit = {},
     photo: @Composable () -> Unit,
     video: @Composable () -> Unit,
 ) {
-    val pageState = rememberPagerState(
-        pageCount = { UiMimeType.TYPES.size },
-        initialPage = state.intValue
-    )
     val handleNavigation by rememberUpdatedState(onNavigate)
+
     Column {
         DesignTab(pageState) { index ->
             UiMimeType.get(index)?.let {
@@ -177,16 +185,22 @@ fun FeedPreview(
             }
         }
     }
-    LaunchedEffect(pageState.currentPage) { handleNavigation(pageState.currentPage) }
+
+    LaunchedEffect(pageState.currentPage) {
+        state.intValue = pageState.currentPage
+        handleNavigation(pageState.currentPage)
+    }
 }
 
 @Composable
 @Preview
 fun PreviewFeedPreview() {
     val state = rememberSaveable { mutableIntStateOf(0) }
+    val pageState = rememberPagerState(pageCount = { UiMimeType.TYPES.size }, initialPage = 0)
     PeerTheme {
         FeedPreview(
             state = state,
+            pageState = pageState,
             modifier = Modifier.fillMaxSize(),
             photo = { Text("Photo") },
             video = { Text("Video") },

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
@@ -27,7 +27,7 @@ fun HomeNavigation(
     ) {
         HomeRoute.ROUTES.forEach { route ->
             composable(route.path) {
-                when(route) {
+                when (route) {
                     is HomeRoute.Home -> FeedScreen(
                         id,
                         BuildConfig.PAGING_LIMIT,
@@ -39,8 +39,21 @@ fun HomeNavigation(
                         component,
                         viewModelStore,
                     )
-                    is HomeRoute.Add -> ComposerScreen(component, viewModelStore)
-                    is HomeRoute.Wallet -> WalletScreen(BuildConfig.PAGING_LIMIT, component, viewModelStore)
+                    is HomeRoute.Add -> ComposerScreen(
+                        component,
+                        viewModelStore,
+                        onPostSuccess = {
+                            navController.navigate(HomeRoute.Home.path) {
+                                popUpTo(HomeRoute.Add.path) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                    is HomeRoute.Wallet -> WalletScreen(
+                        BuildConfig.PAGING_LIMIT,
+                        component,
+                        viewModelStore
+                    )
                     is HomeRoute.Search -> SearchScreen(
                         id,
                         BuildConfig.PAGING_LIMIT,
@@ -53,6 +66,7 @@ fun HomeNavigation(
         }
     }
 }
+
 
 sealed class HomeRoute(
     val icon: Int,

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorScreen.kt
@@ -44,6 +44,7 @@ fun CreatorScreen(
     focus: FocusRequester,
     provider: UiComponentProvider,
     viewModelStoreOwner: ViewModelStoreOwner,
+    onSuccess: () -> Unit
 ) {
     val context = LocalContext.current
     val component = remember {
@@ -117,9 +118,11 @@ fun CreatorScreen(
     LaunchedEffect(shouldReset.value) {
         if (shouldReset.value) {
             viewModel.reset()
+            onSuccess()
         }
     }
 }
+
 
 @Composable
 fun CreatorScreen(


### PR DESCRIPTION
## 📌 Background
 Currently, when users create a new post, the app does not reliably navigate them back to the home feed, causing confusion and disrupting user flow. Additionally, from the video feed page, pressing the back button immediately exits the app, which is unexpected and breaks navigation consistency. Ideally, pressing back from the video feed should navigate the user to the picture feed tab first, then exit on subsequent back presses.
## 🎯 Goal:

- Ensure that after a successful post, the user is navigated back to the home feed screen.
- Fix the back navigation behavior on the video feed page so it first navigates to the picture feed tab instead of exiting immediately.

## ✅ Acceptance Criteria

- After posting, the app navigates automatically to the home feed tab.
- On the video feed tab, pressing back switches the user to the picture feed tab.
- Pressing back on the picture feed tab exits the app.
- Navigation transitions are smooth and consistent with app design.
- No regressions or crashes occur from the navigation changes.

## 🧪 Testing Notes

- Test posting a new item and verify navigation to home feed.
- On video feed, press back once: ensure tab switches to picture feed.
- Press back again on picture feed: ensure app exits.
- Verify navigation state is preserved on screen rotations.
- Test on multiple Android versions and device sizes.
