### PR TITLE
fix(navigation): post success redirects to feed and handles back from…

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerScreen.kt
@@ -41,7 +41,8 @@ import eu.peernetwork.wallet.ui.model.UiToken
 @Composable
 fun ComposerScreen(
     provider: UiComponentProvider,
-    viewModelStore: ViewModelState
+    viewModelStore: ViewModelState,
+    onPostSuccess: () -> Unit
 ) {
     val context = LocalContext.current
     val component = remember {
@@ -53,6 +54,7 @@ fun ComposerScreen(
     val focus = remember { FocusRequester() }
     val intent = UiToken.Post
     val key = intent::class.java.name
+
     Box {
         ComposerNavigation(
             attachment = attachment,
@@ -71,13 +73,15 @@ fun ComposerScreen(
                 },
                 content = {
                     CreatorScreen(
-                        draft,
-                        attachment,
-                        focus,
-                        component,
-                        viewModelStore.get(key),
-                        Modifier.padding(top = 8.dp)
-                            .padding(horizontal = 16.dp)
+                        draft = draft,
+                        attachment = attachment,
+                        focus = focus,
+                        provider = component,
+                        viewModelStoreOwner = viewModelStore.get(key),
+                        modifier = Modifier
+                            .padding(top = 8.dp)
+                            .padding(horizontal = 16.dp),
+                        onSuccess = onPostSuccess
                     )
                     DesignTitleBarHost("CreatorScreen") {
                         titleBar {
@@ -140,7 +144,8 @@ fun PreviewComposerScreen() {
                     enabled = remember { mutableStateOf(false) },
                     error = remember { mutableStateOf(null) },
                     shouldReset = remember { mutableStateOf(false) },
-                    modifier = Modifier.padding(top = 8.dp)
+                    modifier = Modifier
+                        .padding(top = 8.dp)
                         .padding(horizontal = 16.dp)
                 ) {}
             }

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/composer/ComposerScreen.kt
@@ -54,7 +54,6 @@ fun ComposerScreen(
     val focus = remember { FocusRequester() }
     val intent = UiToken.Post
     val key = intent::class.java.name
-
     Box {
         ComposerNavigation(
             attachment = attachment,

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
@@ -65,22 +65,10 @@ fun FeedPreview(
     var position by remember { mutableIntStateOf(state.intValue) }
     val handleOnNavigate by rememberUpdatedState(onNavigate)
     val handleOnFilter by rememberUpdatedState(onFilter)
-
-  
     val pageState = rememberPagerState(
         pageCount = { UiMimeType.TYPES.size },
         initialPage = state.intValue
     )
-
-  
-    BackHandler(enabled = pageState.currentPage == 1) {
-        coroutine.launch {
-            pageState.animateScrollToPage(0)
-        }
-        state.intValue = 0
-        handleOnNavigate(0)
-    }
-
     FeedPreview(
         state = state,
         pageState = pageState,
@@ -132,7 +120,6 @@ fun FeedPreview(
             }
         },
     )
-
     FeedMenu(
         id,
         title,
@@ -150,6 +137,13 @@ fun FeedPreview(
             }
         }
     }
+    BackHandler(enabled = pageState.currentPage == 1) {
+        coroutine.launch {
+            pageState.animateScrollToPage(0)
+        }
+        state.intValue = 0
+        handleOnNavigate(0)
+    }
 }
 
 @Composable
@@ -162,7 +156,6 @@ fun FeedPreview(
     video: @Composable () -> Unit,
 ) {
     val handleNavigation by rememberUpdatedState(onNavigate)
-
     Column {
         DesignTab(pageState) { index ->
             UiMimeType.get(index)?.let {
@@ -187,7 +180,6 @@ fun FeedPreview(
             }
         }
     }
-
     LaunchedEffect(pageState.currentPage) {
         state.intValue = pageState.currentPage
         handleNavigation(pageState.currentPage)

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
@@ -66,13 +66,13 @@ fun FeedPreview(
     val handleOnNavigate by rememberUpdatedState(onNavigate)
     val handleOnFilter by rememberUpdatedState(onFilter)
 
-    // Create PagerState here to control tabs & handle back presses
+  
     val pageState = rememberPagerState(
         pageCount = { UiMimeType.TYPES.size },
         initialPage = state.intValue
     )
 
-    // BackHandler: If user is on video tab (page 1), back press switches to photo tab (page 0)
+  
     BackHandler(enabled = pageState.currentPage == 1) {
         coroutine.launch {
             pageState.animateScrollToPage(0)

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
@@ -1,26 +1,19 @@
 package eu.peernetwork.app.ui.feed
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableIntState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -59,26 +52,43 @@ fun FeedPreview(
     onAuthorClick: (String) -> Unit = {},
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
-    onPhotoClick: (String, Int) -> Unit = { id, position -> },
-    onVideoClick: (String, Int) -> Unit = { id, position -> },
+    onPhotoClick: (String, Int) -> Unit = { _, _ -> },
+    onVideoClick: (String, Int) -> Unit = { _, _ -> },
 ) {
     val photoState = rememberLazyListState()
     val videoState = rememberLazyListState()
     val coroutine = rememberCoroutineScope()
     val connection by connectionController.observe().collectAsStateWithLifecycle()
     var relation by rememberSaveable {
-        mutableStateOf<Relation>(Relation.entries.getOrNull(ordinal)
-            ?: Relation.NONE)
+        mutableStateOf(Relation.entries.getOrNull(ordinal) ?: Relation.NONE)
     }
     var position by remember { mutableIntStateOf(state.intValue) }
     val handleOnNavigate by rememberUpdatedState(onNavigate)
     val handleOnFilter by rememberUpdatedState(onFilter)
+
+    // Create PagerState here to control tabs & handle back presses
+    val pageState = rememberPagerState(
+        pageCount = { UiMimeType.TYPES.size },
+        initialPage = state.intValue
+    )
+
+    // BackHandler: If user is on video tab (page 1), back press switches to photo tab (page 0)
+    BackHandler(enabled = pageState.currentPage == 1) {
+        coroutine.launch {
+            pageState.animateScrollToPage(0)
+        }
+        state.intValue = 0
+        handleOnNavigate(0)
+    }
+
     FeedPreview(
         state = state,
+        pageState = pageState,
         modifier = Modifier.fillMaxSize(),
         onNavigate = {
             position = it
-            handleOnNavigate(it) },
+            handleOnNavigate(it)
+        },
         photo = {
             PhotoScreen(
                 id,
@@ -122,13 +132,15 @@ fun FeedPreview(
             }
         },
     )
+
     FeedMenu(
         id,
         title,
         relation,
         {
             handleOnFilter(it.ordinal)
-            relation = it }
+            relation = it
+        }
     ) {
         coroutine.launch {
             if (position == 0) {
@@ -143,16 +155,14 @@ fun FeedPreview(
 @Composable
 fun FeedPreview(
     state: MutableIntState,
+    pageState: PagerState,
     modifier: Modifier = Modifier,
     onNavigate: (Int) -> Unit = {},
     photo: @Composable () -> Unit,
     video: @Composable () -> Unit,
 ) {
-    val pageState = rememberPagerState(
-        pageCount = { UiMimeType.TYPES.size },
-        initialPage = state.intValue
-    )
     val handleNavigation by rememberUpdatedState(onNavigate)
+
     Column {
         DesignTab(pageState) { index ->
             UiMimeType.get(index)?.let {
@@ -177,16 +187,22 @@ fun FeedPreview(
             }
         }
     }
-    LaunchedEffect(pageState.currentPage) { handleNavigation(pageState.currentPage) }
+
+    LaunchedEffect(pageState.currentPage) {
+        state.intValue = pageState.currentPage
+        handleNavigation(pageState.currentPage)
+    }
 }
 
 @Composable
 @Preview
 fun PreviewFeedPreview() {
     val state = rememberSaveable { mutableIntStateOf(0) }
+    val pageState = rememberPagerState(pageCount = { UiMimeType.TYPES.size }, initialPage = 0)
     PeerTheme {
         FeedPreview(
             state = state,
+            pageState = pageState,
             modifier = Modifier.fillMaxSize(),
             photo = { Text("Photo") },
             video = { Text("Video") },

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
@@ -27,7 +27,7 @@ fun HomeNavigation(
     ) {
         HomeRoute.ROUTES.forEach { route ->
             composable(route.path) {
-                when(route) {
+                when (route) {
                     is HomeRoute.Home -> FeedScreen(
                         id,
                         BuildConfig.PAGING_LIMIT,
@@ -39,8 +39,21 @@ fun HomeNavigation(
                         component,
                         viewModelStore,
                     )
-                    is HomeRoute.Add -> ComposerScreen(component, viewModelStore)
-                    is HomeRoute.Wallet -> WalletScreen(BuildConfig.PAGING_LIMIT, component, viewModelStore)
+                    is HomeRoute.Add -> ComposerScreen(
+                        component,
+                        viewModelStore,
+                        onPostSuccess = {
+                            navController.navigate(HomeRoute.Home.path) {
+                                popUpTo(HomeRoute.Add.path) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                    is HomeRoute.Wallet -> WalletScreen(
+                        BuildConfig.PAGING_LIMIT,
+                        component,
+                        viewModelStore
+                    )
                     is HomeRoute.Search -> SearchScreen(
                         id,
                         BuildConfig.PAGING_LIMIT,
@@ -53,6 +66,7 @@ fun HomeNavigation(
         }
     }
 }
+
 
 sealed class HomeRoute(
     val icon: Int,

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeNavigation.kt
@@ -19,7 +19,8 @@ fun HomeNavigation(
     startDestination: String,
     navController: NavHostController,
     component: Home.Component,
-    viewModelStore: ViewModelState
+    viewModelStore: ViewModelState,
+    onHome: () -> Unit
 ) {
     DesignNavigation(
         navController = navController,
@@ -42,12 +43,7 @@ fun HomeNavigation(
                     is HomeRoute.Add -> ComposerScreen(
                         component,
                         viewModelStore,
-                        onPostSuccess = {
-                            navController.navigate(HomeRoute.Home.path) {
-                                popUpTo(HomeRoute.Add.path) { inclusive = true }
-                                launchSingleTop = true
-                            }
-                        }
+                        onPostSuccess = onHome
                     )
                     is HomeRoute.Wallet -> WalletScreen(
                         BuildConfig.PAGING_LIMIT,

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/home/HomeScreen.kt
@@ -30,6 +30,7 @@ import eu.peernetwork.core.ui.theme.PeerTheme
 import eu.peernetwork.core.ui.design.component.DesignStatefulScaffold
 import eu.peernetwork.core.ui.design.component.DesignStatefulScaffoldState
 import eu.peernetwork.core.ui.design.compose.DesignTitleBar
+import eu.peernetwork.core.ui.extension.attach
 import eu.peernetwork.core.ui.extension.attachIfNecessary
 import eu.peernetwork.core.ui.model.ViewModelState
 import eu.peernetwork.wallet.ui.reward.RewardScreen
@@ -85,7 +86,11 @@ fun HomeScreen(provider: UiComponentProvider) {
                 navController = controller,
                 component = component,
                 viewModelStore = viewModelStore
-            )
+            ) {
+                viewModel.lastVisited(0)
+                navigationState.intValue = 0
+                controller.attach(HomeRoute.Home.path)
+            }
         }
         BackHandler(enabled = currentStack.value != HomeRoute.Home.path) {
             viewModel.lastVisited(0)

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorScreen.kt
@@ -1,5 +1,6 @@
 package eu.peernetwork.blog.ui.creator
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -22,11 +23,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import eu.peernetwork.blog.ui.R
 import eu.peernetwork.blog.ui.engagement.EngagementConfirmation
 import eu.peernetwork.blog.ui.engagement.EngagementType
 import eu.peernetwork.blog.ui.model.UiDraft
@@ -83,6 +86,8 @@ fun CreatorScreen(
     val type = remember(draft.value) {
         mutableStateOf<EngagementType?>(draft.value?.let { EngagementType.Post(it) })
     }
+    val handleOnSuccess by rememberUpdatedState(onSuccess)
+    val successMessage = stringResource(R.string.post_success_message)
     CreatorScreen(
         focus = focus,
         onSubmit = {
@@ -119,7 +124,8 @@ fun CreatorScreen(
     LaunchedEffect(shouldReset.value) {
         if (shouldReset.value) {
             viewModel.reset()
-            onSuccess()
+            Toast.makeText(context, successMessage, Toast.LENGTH_SHORT).show()
+            handleOnSuccess()
         }
     }
     DisposableEffect(Unit) {

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorScreen.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorScreen.kt
@@ -44,7 +44,8 @@ fun CreatorScreen(
     focus: FocusRequester,
     provider: UiComponentProvider,
     viewModelStoreOwner: ViewModelStoreOwner,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onSuccess: () -> Unit = {}
 ) {
     val context = LocalContext.current
     val component = remember {
@@ -91,7 +92,7 @@ fun CreatorScreen(
                 media = if (attachment.value.files.isEmpty()) {
                     UiMimeType.Text
                 } else { attachment.value.media },
-                attachments = attachment.value.files.map { it.uri }
+                attachments = attachment.value.files.map { file -> file.uri }
             ) },
         onReset = { attachment.value = UiAttachment.Text },
         isLoading = isLoading,
@@ -118,6 +119,7 @@ fun CreatorScreen(
     LaunchedEffect(shouldReset.value) {
         if (shouldReset.value) {
             viewModel.reset()
+            onSuccess()
         }
     }
     DisposableEffect(Unit) {
@@ -148,7 +150,8 @@ fun CreatorScreen(
     ) {
         DesignLabel(
             label = { error.value?.let {
-                Text(it,
+                Text(
+                    it,
                     modifier = Modifier.padding(horizontal = 16.dp)
                         .padding(vertical = 8.dp),
                     style = MaterialTheme.typography.bodySmall.copy(
@@ -158,7 +161,9 @@ fun CreatorScreen(
             }},
             visible = error.value != null,
             modifier = Modifier.padding(bottom = 4.dp)
-        ) { CreatorForm(title, focus, description, isLoading) }
+        ) {
+            CreatorForm(title, focus, description, isLoading)
+        }
         Spacer(modifier = Modifier.height(8.dp))
         CreatorFooter(
             title = title,

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/usecase/BackgroundUsecase.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/usecase/BackgroundUsecase.kt
@@ -17,21 +17,22 @@ class BackgroundUsecase @Inject constructor(
         if (bitmap != null) {
             interactor.invalidate()
             bitmap
-        }
-        interactor.get(
-            param.url, param.type, 200, Pair(50f, 50f)
-        )?.let { background ->
+        } else {
             interactor.get(
-                param.url, param.type, null, Pair(500f, 500f)
-            )?.let { foreground ->
-                interactor.merge(
-                    param.url,
-                    param.type,
-                    param.width,
-                    param.aspectRatio,
-                    background,
-                    foreground
-                )
+                param.url, param.type, 200, Pair(50f, 50f)
+            )?.let { background ->
+                interactor.get(
+                    param.url, param.type, null, Pair(350f, 350f)
+                )?.let { foreground ->
+                    interactor.merge(
+                        param.url,
+                        param.type,
+                        param.width,
+                        param.aspectRatio,
+                        background,
+                        foreground
+                    )
+                }
             }
         }
     }

--- a/blog/ui/src/main/res/values/strings.xml
+++ b/blog/ui/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="post_title">Mood update 😎</string>
     <string name="post_description">Write a post…</string>
     <string name="post_reply">Write a comment…</string>
+    <string name="post_success_message">Post successfully sent!</string>
     <string name="send_label">Send</string>
 
     <string name="now_label">Just now</string>


### PR DESCRIPTION
## 📌 Background
 Currently, when users create a new post, the app does not reliably navigate them back to the home feed, causing confusion and disrupting user flow. Additionally, from the video feed page, pressing the back button immediately exits the app, which is unexpected and breaks navigation consistency. Ideally, pressing back from the video feed should navigate the user to the picture feed tab first, then exit on subsequent back presses.
## 🎯 Goal:

- Ensure that after a successful post, the user is navigated back to the home feed screen.
- Fix the back navigation behavior on the video feed page so it first navigates to the picture feed tab instead of exiting immediately.

## ✅ Acceptance Criteria

- After posting, the app navigates automatically to the home feed tab.
- On the video feed tab, pressing back switches the user to the picture feed tab.
- Pressing back on the picture feed tab exits the app.
- Navigation transitions are smooth and consistent with app design.
- No regressions or crashes occur from the navigation changes.
