### PR TITLE
feat(profile): add expandable bio with show more/less toggle

### DIFF
--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignLead.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignLead.kt
@@ -1,27 +1,36 @@
 package eu.peernetwork.core.ui.design.compose
 
 import android.content.res.Configuration
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import eu.peernetwork.core.ui.extension.annotate
 import eu.peernetwork.core.ui.theme.PeerTheme
+import androidx.compose.ui.res.stringResource
+import eu.peernetwork.core.ui.R
 
 data class DesignTitleStyle(
     val span: SpanStyle,
@@ -36,7 +45,6 @@ fun DesignLead(
     description: String,
     modifier: Modifier = Modifier,
     maxLines: Int = Int.MAX_VALUE,
-    maxContentLines: Int = Int.MAX_VALUE,
     spacer: @Composable () -> Unit = {},
     style: DesignTitleStyle? = null,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
@@ -76,15 +84,50 @@ fun DesignLead(
         )
         updateSpacer()
         if (description.isNotEmpty()) {
-            Text(
+            ExpandableText(
                 text = description,
-                maxLines = maxContentLines,
-                overflow = TextOverflow.Ellipsis,
-                style = textStyle.descriptionStyle,
-                modifier = Modifier.padding(
-                    top = 2.dp,
-                    end = 4.dp
+                textStyle = textStyle.descriptionStyle,
                 )
+        }
+    }
+}
+
+@Composable
+private fun ExpandableText(
+    text: String,
+    textStyle: TextStyle,
+    minimizedMaxLines: Int = 3
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+    var textLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+
+    val showMoreNeeded = remember(textLayoutResult, isExpanded) {
+        !isExpanded && (textLayoutResult?.hasVisualOverflow ?: false)
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = text,
+            style = textStyle,
+            maxLines = if (isExpanded) Int.MAX_VALUE else minimizedMaxLines,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { textLayoutResult = it },
+            modifier = Modifier
+                .padding(top = 2.dp, end = 4.dp)
+        )
+
+        if (showMoreNeeded || isExpanded) {
+            val label = if (isExpanded) stringResource(R.string.show_less) else stringResource(R.string.show_more)
+            Text(
+                text = label,
+                color = MaterialTheme.colorScheme.tertiary,
+                style = MaterialTheme.typography.labelMedium.copy(
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Right
+                ),
+                modifier = Modifier
+                    .padding(top = 4.dp)
+                    .clickable { isExpanded = !isExpanded }
             )
         }
     }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -22,4 +22,7 @@
     <string name="refresh_message">Pull down to refresh</string>
     <string name="empty_message">No result found!</string>
     <string name="unknown_error_message">Oops! Unknown network error occurred.</string>
+    
+    <string name="show_more">More</string>
+    <string name="show_less">Less</string>
 </resources>


### PR DESCRIPTION
### Summary
This PR adds an expandable bio description feature in the user profile screen. By default, bios are limited to 3 lines with a "Show more" button to expand and a "Show less" button to collapse the text.

---
### Changes
- Updated DesignLead.kt to support expandable description text
- Added strings for localization in core/ui/src/main/res/values/strings.xml
- Styled the toggle button to align right, bold, and theme-consistent colors

---
### Testing
- Tested with short and long bios
- Verified toggle functionality on tap
- Verified string resource usage


