### PR TITLE
feat(post-text): add expandable More/Less logic to bio and media posts

### DIFF
--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/compose/PostDescription.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/compose/PostDescription.kt
@@ -6,11 +6,21 @@ import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import eu.peernetwork.core.ui.R
 
 @Composable
 fun PostText(
@@ -23,11 +33,81 @@ fun PostText(
     val handleMention by rememberUpdatedState(onMentionClick)
     val handleHashTag by rememberUpdatedState(onHashtagClick)
     val uriHandler = LocalUriHandler.current
+
+    var isExpanded by remember { mutableStateOf(false) }
+    var readyToDraw by remember { mutableStateOf(false) }
+    var cutDescription by remember { mutableStateOf(description) }
+    var showMoreNeeded by remember { mutableStateOf(false) }
+
+
+    val showMoreText = stringResource(id = R.string.show_more_text)
+    val showLessText = stringResource(id = R.string.show_less_text)
+
+    val linkColor = MaterialTheme.colorScheme.tertiary
+    val linkFontWeight = FontWeight.Bold
+
+    fun AnnotatedString.sliceAnnotatedString(start: Int, end: Int): AnnotatedString {
+        if (start >= end || start < 0 || end > this.length) return AnnotatedString("")
+
+        val subText = this.text.substring(start, end)
+        val builder = AnnotatedString.Builder(subText)
+
+        this.spanStyles.filter { style ->
+            style.start < end && style.end > start
+        }.forEach { style ->
+            val sliceStart = (style.start - start).coerceAtLeast(0)
+            val sliceEnd = (style.end - start).coerceAtMost(subText.length)
+            if (sliceStart < sliceEnd) {
+                builder.addStyle(style.item, sliceStart, sliceEnd)
+            }
+        }
+
+        this.getStringAnnotations(start, end).forEach { annotation ->
+            val sliceStart = (annotation.start - start).coerceAtLeast(0)
+            val sliceEnd = (annotation.end - start).coerceAtMost(subText.length)
+            if (sliceStart < sliceEnd) {
+                builder.addStringAnnotation(annotation.tag, annotation.item, sliceStart, sliceEnd)
+            }
+        }
+
+        return builder.toAnnotatedString()
+    }
+
+    val annotatedDescription = remember(isExpanded, cutDescription, showMoreNeeded) {
+        if (isExpanded) {
+            buildAnnotatedString {
+                append(cutDescription)
+                append(" ")
+                pushStringAnnotation(tag = "SHOW_LESS", annotation = "show_less")
+                withStyle(
+                    style = SpanStyle(color = linkColor, fontWeight = linkFontWeight)
+                ) {
+                    append(showLessText)
+                }
+                pop()
+            }
+        } else {
+            buildAnnotatedString {
+                append(cutDescription)
+                if (showMoreNeeded) {
+                    pushStringAnnotation(tag = "SHOW_MORE", annotation = "show_more")
+                    withStyle(
+                        style = SpanStyle(color = linkColor, fontWeight = linkFontWeight)
+                    ) {
+                        append(showMoreText)
+                    }
+                    pop()
+                }
+            }
+        }
+    }
+
     Column(modifier = modifier) {
         ClickableText(
             text = title,
-            style = MaterialTheme.typography.headlineMedium.copy(
-                color = MaterialTheme.colorScheme.onBackground
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = MaterialTheme.colorScheme.onBackground,
+                fontWeight = FontWeight.Bold
             ),
             onClick = { offset ->
                 val annotations = title.getStringAnnotations(start = offset, end = offset)
@@ -40,13 +120,51 @@ fun PostText(
                 }
             }
         )
+
         ClickableText(
-            text = description,
+            text = annotatedDescription,
             style = MaterialTheme.typography.bodyMedium.copy(
                 color = MaterialTheme.colorScheme.tertiary,
             ),
             modifier = Modifier.padding(top = 4.dp),
+            maxLines = if (isExpanded) Int.MAX_VALUE else 3,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { layoutResult ->
+
+                if (!isExpanded) {
+                    if (!readyToDraw) {
+                        if (layoutResult.hasVisualOverflow) {
+                            val lastVisibleCharIndex = layoutResult.getLineEnd(2, visibleEnd = true)
+                            val cutoffIndex = (lastVisibleCharIndex - showMoreText.length).coerceAtLeast(0)
+                            cutDescription = description.sliceAnnotatedString(0, cutoffIndex)
+                            showMoreNeeded = true
+                        } else {
+                            cutDescription = description
+                            showMoreNeeded = false
+                        }
+                        readyToDraw = true
+                    }
+                } else {
+
+                    cutDescription = description
+                    showMoreNeeded = false
+                    readyToDraw = false
+                }
+            },
             onClick = { offset ->
+                annotatedDescription.getStringAnnotations(tag = "SHOW_MORE", start = offset, end = offset)
+                    .firstOrNull()?.let {
+                        isExpanded = true
+                        readyToDraw = false
+                        return@ClickableText
+                    }
+                annotatedDescription.getStringAnnotations(tag = "SHOW_LESS", start = offset, end = offset)
+                    .firstOrNull()?.let {
+                        isExpanded = false
+                        readyToDraw = false
+                        return@ClickableText
+                    }
+
                 val annotations = description.getStringAnnotations(start = offset, end = offset)
                 annotations.firstOrNull()?.let { annotation ->
                     when (annotation.tag) {

--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignLead.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignLead.kt
@@ -1,32 +1,35 @@
 package eu.peernetwork.core.ui.design.compose
 
 import android.content.res.Configuration
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import eu.peernetwork.core.ui.R
 import eu.peernetwork.core.ui.extension.annotate
 import eu.peernetwork.core.ui.theme.PeerTheme
 
 data class DesignTitleStyle(
     val span: SpanStyle,
-    val style: TextStyle,
-    val descriptionStyle: TextStyle,
+    val style: androidx.compose.ui.text.TextStyle,
+    val descriptionStyle: androidx.compose.ui.text.TextStyle,
 )
 
 @Composable
@@ -36,7 +39,7 @@ fun DesignLead(
     description: String,
     modifier: Modifier = Modifier,
     maxLines: Int = Int.MAX_VALUE,
-    maxContentLines: Int = Int.MAX_VALUE,
+    maxContentLines: Int = 3,
     spacer: @Composable () -> Unit = {},
     style: DesignTitleStyle? = null,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
@@ -63,6 +66,48 @@ fun DesignLead(
             color = MaterialTheme.colorScheme.tertiary
         )
     )
+
+    var isExpanded by remember { mutableStateOf(false) }
+    var readyToDraw by remember { mutableStateOf(false) }
+    var cutDescription by remember { mutableStateOf(description) }
+    var showMoreNeeded by remember { mutableStateOf(false) }
+
+    val showMoreText = stringResource(id = R.string.show_more_text)
+    val showLessText = stringResource(id = R.string.show_less_text)
+
+    val linkColor = MaterialTheme.colorScheme.tertiary
+    val linkFontWeight = FontWeight.Bold
+
+
+    val annotatedDescription = remember(isExpanded, cutDescription, showMoreNeeded) {
+        if (isExpanded) {
+            buildAnnotatedString {
+                append(cutDescription)
+                append(" ")
+                pushStringAnnotation(tag = "SHOW_LESS", annotation = "show_less")
+                withStyle(
+                    style = SpanStyle(color = linkColor, fontWeight = linkFontWeight)
+                ) {
+                    append(showLessText)
+                }
+                pop()
+            }
+        } else {
+            buildAnnotatedString {
+                append(cutDescription)
+                if (showMoreNeeded) {
+                    pushStringAnnotation(tag = "SHOW_MORE", annotation = "show_more")
+                    withStyle(
+                        style = SpanStyle(color = linkColor, fontWeight = linkFontWeight)
+                    ) {
+                        append(showMoreText)
+                    }
+                    pop()
+                }
+            }
+        }
+    }
+
     Column(
         modifier = modifier,
         verticalArrangement = verticalArrangement,
@@ -76,15 +121,55 @@ fun DesignLead(
         )
         updateSpacer()
         if (description.isNotEmpty()) {
-            Text(
-                text = description,
-                maxLines = maxContentLines,
+            ClickableText(
+                text = annotatedDescription,
+                maxLines = if (isExpanded) Int.MAX_VALUE else maxContentLines,
                 overflow = TextOverflow.Ellipsis,
                 style = textStyle.descriptionStyle,
-                modifier = Modifier.padding(
-                    top = 2.dp,
-                    end = 4.dp
-                )
+                modifier = Modifier
+                    .padding(
+                        top = 2.dp,
+                        end = 4.dp
+                    )
+                    .animateContentSize(),
+                onTextLayout = { layoutResult ->
+                    if (!isExpanded) {
+                        if (!readyToDraw) {
+                            if (layoutResult.hasVisualOverflow) {
+                                val lastVisibleCharIndex = layoutResult.getLineEnd(
+                                    maxContentLines - 1,
+                                    visibleEnd = true
+                                )
+                                val cutoffIndex = (lastVisibleCharIndex - showMoreText.length).coerceAtLeast(0)
+                                cutDescription = description.substring(0, cutoffIndex)
+                                showMoreNeeded = true
+                            } else {
+                                cutDescription = description
+                                showMoreNeeded = false
+                            }
+                            readyToDraw = true
+                        }
+                    } else {
+
+                        cutDescription = description
+                        showMoreNeeded = false
+                        readyToDraw = false
+                    }
+                },
+                onClick = { offset ->
+                    annotatedDescription.getStringAnnotations(tag = "SHOW_MORE", start = offset, end = offset)
+                        .firstOrNull()?.let {
+                            isExpanded = true
+                            readyToDraw = false
+                            return@ClickableText
+                        }
+                    annotatedDescription.getStringAnnotations(tag = "SHOW_LESS", start = offset, end = offset)
+                        .firstOrNull()?.let {
+                            isExpanded = false
+                            readyToDraw = false
+                            return@ClickableText
+                        }
+                }
             )
         }
     }
@@ -98,13 +183,15 @@ fun PreviewDesignTitle() {
             DesignLead(
                 title = "John Doe",
                 caption = "1675262",
-                description = "Hello, John...",
+                description = "Hello, John, this is a longer description that will demonstrate how the more less expandable text works in the DesignLead component.",
+                maxContentLines = 3
             )
             Spacer(modifier = Modifier.height(12.dp))
             DesignLead(
                 title = "John Doe",
                 caption = "",
-                description = "Hello, John...",
+                description = "Hello, John, this is a longer description that will demonstrate how the more less expandable text works in the DesignLead component.",
+                maxContentLines = 3
             )
             Spacer(modifier = Modifier.height(12.dp))
             DesignLead(

--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignRichText.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignRichText.kt
@@ -5,18 +5,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import eu.peernetwork.core.ui.R
 
 @Composable
 fun DesignRichText(
@@ -24,7 +26,7 @@ fun DesignRichText(
     description: AnnotatedString,
     modifier: Modifier = Modifier,
     maxLines: Int = Int.MAX_VALUE,
-    maxContentLines: Int = Int.MAX_VALUE,
+    maxContentLines: Int = 2,
     spacer: @Composable () -> Unit = {},
     style: DesignTitleStyle? = null,
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
@@ -37,21 +39,91 @@ fun DesignRichText(
         span = SpanStyle(
             fontStyle = FontStyle.Italic,
             fontWeight = FontWeight.Normal,
-            fontSize = MaterialTheme.typography.bodySmall.fontSize,
+            fontSize = MaterialTheme.typography.bodyMedium .fontSize,
             color = MaterialTheme.colorScheme.tertiary
         ),
         style = MaterialTheme.typography.bodyMedium.copy(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground
         ),
-        descriptionStyle = MaterialTheme.typography.bodySmall.copy(
-            color = MaterialTheme.colorScheme.tertiary
+        descriptionStyle = MaterialTheme.typography.bodyMedium.copy(
+            color = MaterialTheme.colorScheme.tertiary,
         )
     )
     val uriHandler = LocalUriHandler.current
     val handleTitleOnClick by rememberUpdatedState(titleOnClick)
     val handleMentionClick by rememberUpdatedState(onMentionClick)
     val handleHashtagClick by rememberUpdatedState(onHashtagClick)
+
+    var isExpanded by remember { mutableStateOf(false) }
+    var readyToDraw by remember { mutableStateOf(false) }
+    var cutDescription by remember { mutableStateOf(description) }
+    var showMoreNeeded by remember { mutableStateOf(false) }
+
+    val showMoreText = stringResource(id = R.string.show_more_text)
+    val showLessText = stringResource(id = R.string.show_less_text)
+
+
+    val linkColor = MaterialTheme.colorScheme.tertiary
+    val linkFontWeight = FontWeight.Bold
+
+
+    fun AnnotatedString.sliceAnnotatedString(start: Int, end: Int): AnnotatedString {
+        if (start >= end || start < 0 || end > this.length) return AnnotatedString("")
+
+        val subText = this.text.substring(start, end)
+        val builder = AnnotatedString.Builder(subText)
+
+        this.spanStyles.filter { style ->
+            style.start < end && style.end > start
+        }.forEach { style ->
+            val sliceStart = (style.start - start).coerceAtLeast(0)
+            val sliceEnd = (style.end - start).coerceAtMost(subText.length)
+            if (sliceStart < sliceEnd) {
+                builder.addStyle(style.item, sliceStart, sliceEnd)
+            }
+        }
+
+        this.getStringAnnotations(start, end).forEach { annotation ->
+            val sliceStart = (annotation.start - start).coerceAtLeast(0)
+            val sliceEnd = (annotation.end - start).coerceAtMost(subText.length)
+            if (sliceStart < sliceEnd) {
+                builder.addStringAnnotation(annotation.tag, annotation.item, sliceStart, sliceEnd)
+            }
+        }
+
+        return builder.toAnnotatedString()
+    }
+
+    val annotatedDescription = remember(isExpanded, cutDescription, showMoreNeeded) {
+        if (isExpanded) {
+            buildAnnotatedString {
+                append(cutDescription)
+                append(" ")
+                pushStringAnnotation(tag = "SHOW_LESS", annotation = "show_less")
+                withStyle(
+                    style = SpanStyle(color = linkColor, fontWeight = linkFontWeight)
+                ) {
+                    append(showLessText)
+                }
+                pop()
+            }
+        } else {
+            buildAnnotatedString {
+                append(cutDescription)
+                if (showMoreNeeded) {
+                    pushStringAnnotation(tag = "SHOW_MORE", annotation = "show_more")
+                    withStyle(
+                        style = SpanStyle(color = linkColor, fontWeight = linkFontWeight)
+                    ) {
+                        append(showMoreText)
+                    }
+                    pop()
+                }
+            }
+        }
+    }
+
     Column(
         modifier = modifier,
         verticalArrangement = verticalArrangement,
@@ -76,12 +148,48 @@ fun DesignRichText(
         spacer()
         if (description.isNotEmpty()) {
             ClickableText(
-                text = description,
-                maxLines = maxContentLines,
+                text = annotatedDescription,
+                maxLines = if (isExpanded) Int.MAX_VALUE else maxContentLines,
                 overflow = TextOverflow.Ellipsis,
                 style = textStyle.descriptionStyle,
                 modifier = Modifier.padding(top = 2.dp),
+                onTextLayout = { layoutResult ->
+                    if (!isExpanded) {
+                        if (!readyToDraw) {
+                            if (layoutResult.hasVisualOverflow) {
+                                val lastVisibleCharIndex = layoutResult.getLineEnd(
+                                    maxContentLines - 1,
+                                    visibleEnd = true
+                                )
+                                val cutoffIndex = (lastVisibleCharIndex - showMoreText.length).coerceAtLeast(0)
+                                cutDescription = description.sliceAnnotatedString(0, cutoffIndex)
+                                showMoreNeeded = true
+                            } else {
+                                cutDescription = description
+                                showMoreNeeded = false
+                            }
+                            readyToDraw = true
+                        }
+                    } else {
+                        cutDescription = description
+                        showMoreNeeded = false
+                        readyToDraw = false
+                    }
+                },
                 onClick = { offset ->
+                    annotatedDescription.getStringAnnotations(tag = "SHOW_MORE", start = offset, end = offset)
+                        .firstOrNull()?.let {
+                            isExpanded = true
+                            readyToDraw = false
+                            return@ClickableText
+                        }
+                    annotatedDescription.getStringAnnotations(tag = "SHOW_LESS", start = offset, end = offset)
+                        .firstOrNull()?.let {
+                            isExpanded = false
+                            readyToDraw = false
+                            return@ClickableText
+                        }
+
                     val annotations = description.getStringAnnotations(start = offset, end = offset)
                     annotations.firstOrNull()?.let { annotation ->
                         when (annotation.tag) {

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -22,4 +22,7 @@
     <string name="refresh_message">Pull down to refresh</string>
     <string name="empty_message">No result found!</string>
     <string name="unknown_error_message">Oops! Unknown network error occurred.</string>
+
+    <string name="show_more_text">... More</string>
+    <string name="show_less_text">Less</string>
 </resources>


### PR DESCRIPTION
This update enhances the display of textual content across different post types and the user bio section by introducing an expandable "More/Less" feature with specific line limits:

- Video and Picture Posts: Text descriptions now show a preview limited to 2 lines. If the content exceeds this limit, a clickable "More" link appears inline to expand the full text, improving readability and preserving screen space.

- User Bio Section: Displays up to 3 lines initially, also with the expandable "More/Less" toggle for longer bios, enhancing user profile clarity without overwhelming the UI.

- Reusability: The solution leverages the existing expandable text logic template used in other components, ensuring consistency in UX and maintainability.

- Performance & UX: The "More/Less" links are styled with clear visual cues and respond to user interaction smoothly. No additional dependencies were added, maintaining the app's lightweight nature.

- No Dependency Changes: The implementation adheres to current project constraints, avoiding any new library additions.

This change aims to optimize text presentation dynamically, making the app’s interface cleaner and more user-friendly.

