### PR TITLE
Srivetrikumaran/fix/keyboard scroll post

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -48,6 +49,7 @@ fun FeedPreview(
     connectionController: ConnectionController,
     title: String? = null,
     criteria: Criteria? = null,
+    listState: LazyListState,
     onNavigate: (Int) -> Unit = {},
     onFilter: (Int) -> Unit = {},
     onAuthorClick: (String) -> Unit = {},
@@ -56,8 +58,8 @@ fun FeedPreview(
     onPhotoClick: (String, Int) -> Unit = { _, _ -> },
     onVideoClick: (String, Int) -> Unit = { _, _ -> },
 ) {
-    val photoState = rememberLazyListState()
-    val videoState = rememberLazyListState()
+    val photoState = listState
+    val videoState = listState
     val coroutine = rememberCoroutineScope()
     val connection by connectionController.observe().collectAsStateWithLifecycle()
     var relation by rememberSaveable {

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedPreview.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState

--- a/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/feed/FeedScreen.kt
@@ -1,14 +1,12 @@
 package eu.peernetwork.app.ui.feed
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import eu.peernetwork.blog.domain.model.Filter.Criteria
 import eu.peernetwork.core.ui.component.UiComponentProvider
@@ -24,6 +22,7 @@ fun FeedScreen(
     provider: UiComponentProvider,
     viewModelStore: ViewModelState,
     title: String? = null,
+    controller: NavHostController = rememberNavController(),
     criteria: Criteria? = null
 ) {
     val context = LocalContext.current
@@ -31,6 +30,16 @@ fun FeedScreen(
         provider.builder(Feed.Builder::class.java).build(context)
     }
     val viewModelStoreOwner = viewModelStore.get(criteria?.toString() ?: id)
+    val navBackStackEntry by controller.currentBackStackEntryAsState()
+    val scrollToTop = remember { mutableStateOf(false) }
+    val listState = rememberLazyListState()
+    LaunchedEffect(navBackStackEntry) {
+        scrollToTop.value = true }
+    LaunchedEffect(scrollToTop.value) {
+        if (scrollToTop.value) {
+            listState.scrollToItem(0)
+            scrollToTop.value = false }
+    }
     val viewModel = viewModel(
         modelClass = FeedViewModel::class.java,
         viewModelStoreOwner = viewModelStoreOwner,
@@ -44,7 +53,7 @@ fun FeedScreen(
         }
     }
     val overlay = remember { mutableStateOf<FeedOverlayState>(FeedOverlayState.Empty) }
-    val controller = rememberNavController()
+
     FeedOverlay(
         overlay = overlay,
         userId = id,
@@ -81,7 +90,8 @@ fun FeedScreen(
                     onFilter = { viewModel.setFilter(it) },
                     onPhotoClick = { id, index -> },
                     onVideoClick = { id, index ->
-                        overlay.value = FeedOverlayState.Video(id, index) }
+                        overlay.value = FeedOverlayState.Video(id, index)
+                    }, listState = listState
                 )
             }
         }

--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorForm.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/creator/CreatorForm.kt
@@ -15,7 +15,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -34,6 +43,10 @@ fun CreatorForm(
     description: TextFieldState,
     isLoading: State<Boolean>,
 ) {
+    val descriptionFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager: FocusManager = LocalFocusManager.current
+
     Column {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -42,8 +55,17 @@ fun CreatorForm(
             DesignTextField(
                 state = title,
                 enabled = !isLoading.value,
-                modifier = Modifier.weight(1f),
-                focusRequester = focus,
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focus)
+                    .onKeyEvent { keyEvent ->
+                        if (keyEvent.type == KeyEventType.KeyUp && keyEvent.key == Key.Enter) {
+                            descriptionFocusRequester.requestFocus()
+                            true
+                        } else {
+                            false
+                        }
+                    },
                 keyboardOptions = KeyboardOptions(
                     capitalization = KeyboardCapitalization.Sentences,
                     keyboardType = KeyboardType.Text,
@@ -63,14 +85,25 @@ fun CreatorForm(
             keyboardOptions = KeyboardOptions(
                 capitalization = KeyboardCapitalization.Sentences,
                 keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Next
+                imeAction = ImeAction.Done
             ),
             verticalAlignment = Alignment.Top,
             maxLines = 3,
             maxLength = 500,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 12.dp),
+                .padding(top = 12.dp)
+                .focusRequester(descriptionFocusRequester)
+                .onKeyEvent { keyEvent ->
+                    if (keyEvent.type == KeyEventType.KeyUp && keyEvent.key == Key.Enter) {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                        true
+                    } else {
+                        false
+                    }
+                },
+
             leading = {
                 Text(
                     text = stringResource(R.string.description_label),
@@ -97,7 +130,7 @@ fun PreviewCreatorForm() {
             title = title,
             focus = focus,
             description = description,
-            isLoading = remember { mutableStateOf(false) }
+            isLoading = remember {mutableStateOf(false) }
         )
     }
 }


### PR DESCRIPTION
# 🔧 Fix: Keyboard Navigation & Feed Scroll Position After Post
## 📌 Background
When pressing "Enter" in the Description field, the keyboard should dismiss. But currently, it shifts focus back to the Mood Update field, which is not expected.

After posting media (picture or video), the feed does not auto-scroll to the top, making it harder to view new content.

## 🎯 Goal

-  Smooth keyboard navigation between Mood Update and Description.
-  Dismiss keyboard on Enter in Description, without refocusing.
-  Scroll to top of the feed after media post (Picture or Video tab).

## ✅ Acceptance Criteria

-  Enter on Mood Update moves focus to Description.
-  Enter on Description hides keyboard.
-  No refocus from Description to Mood Update.
-  Feed scrolls to top automatically after media post (Picture/Video).
-  Behavior consistent across Android versions and devices.
-  No regression in other keyboard/focus behavior or scrolling.
