### PR TITLE
feat(upload): replace media type text with icons and dropdown indicator

### DIFF
--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignDropDown.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/design/compose/DesignDropDown.kt
@@ -118,7 +118,7 @@ fun DesignDropDown(
                                         state.value = false
                                     }
                                 }
-                            ).padding(contentPadding)
+                            ).padding(vertical = 0.7.dp)
                         ) { item.value.content(item.value.tag, false) }
                     }
                 }

--- a/media/ui/src/main/kotlin/eu/peernetwork/media/ui/selector/explorer/ExplorerScreen.kt
+++ b/media/ui/src/main/kotlin/eu/peernetwork/media/ui/selector/explorer/ExplorerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -32,6 +33,7 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -46,7 +48,6 @@ import eu.peernetwork.core.ui.design.compose.DesignTitle
 import eu.peernetwork.core.ui.design.compose.DesignTitleBarHost
 import eu.peernetwork.core.ui.extension.builder
 import eu.peernetwork.core.ui.model.ViewModelState
-import eu.peernetwork.core.ui.theme.PeerTheme
 import eu.peernetwork.media.core.model.UiAttachment
 import eu.peernetwork.media.core.model.UiMimeType
 import eu.peernetwork.media.ui.R
@@ -138,7 +139,7 @@ fun ExplorerScreen(
     val updatedContent by rememberUpdatedState(content)
     Column {
         val border = MaterialTheme.colorScheme.surfaceVariant
-        var expanded = remember { mutableStateOf(false) }
+        val expanded = remember { mutableStateOf(false) }
         val photo = stringResource(R.string.photo_label)
         val video = stringResource(R.string.video_label)
         val files = stringResource(R.string.file_label)
@@ -166,49 +167,75 @@ fun ExplorerScreen(
             .padding(vertical = 12.dp, horizontal = 24.dp)) {
             DesignDropDown(
                 expanded,
+                contentPadding = PaddingValues(vertical = 4.dp),
                 default = title.value,
-                modifier = Modifier.padding(top = 4.dp)
-                    .clip(RoundedCornerShape(16))
-                    .background(color = border)
+                modifier = Modifier
+                    .padding(vertical = 6.dp)
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
             ) {
-                item(tag = photo, {
-                    title.value = photo
-                    onSelect(UiMimeType.Photo)
-                    true
-                }) { label, isActive ->
-                    Text(
-                        label,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    )
-                }
-                item(tag = video, {
-                    title.value = video
-                    onSelect(UiMimeType.Video)
-                    true
-                }) { label, isActive ->
-                    Text(
-                        label,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    )
-                }
-                item(tag = files, {
-                    handleOnClick()
-                    expanded.value = false
-                    false
-                }) { label, isActive ->
-                    Text(
-                        label,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.onBackground
-                        )
-                    )
+                val items = mapOf(
+                    photo to eu.peernetwork.core.ui.R.drawable.ic_photo,
+                    video to eu.peernetwork.core.ui.R.drawable.ic_video,
+                    files to eu.peernetwork.core.ui.R.drawable.ic_wallet
+                )
+
+                items.entries.forEach { (label, iconRes) ->
+                    item(tag = label, {
+                        when (label) {
+                            photo -> {
+                                title.value = photo
+                                onSelect(UiMimeType.Photo)
+                            }
+                            video -> {
+                                title.value = video
+                                onSelect(UiMimeType.Video)
+                            }
+                            files -> {
+                                handleOnClick()
+                                expanded.value = false
+                            }
+                        }
+                        true
+                    }) { _, isActive ->
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(start = 8.dp).padding(vertical = 4.dp)
+                        ) {
+                            androidx.compose.material3.Icon(
+                                painter = painterResource(id = iconRes),
+                                contentDescription = label,
+                                modifier = Modifier.size(20.dp),
+                                tint = if (isActive) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.tertiary
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                label,
+                                style = if (isActive) {
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        MaterialTheme.colorScheme.onBackground
+                                    )
+                                } else {
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        MaterialTheme.colorScheme.tertiary
+                                    )
+                                },
+                            )
+                            if (isActive) {
+                                Spacer(modifier = Modifier.width(2.dp))
+                                androidx.compose.material3.Icon(
+                                    painter = painterResource(id = eu.peernetwork.core.ui.R.drawable.ic_caret_down),
+                                    contentDescription = "Selected",
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.onSurface
+                                )
+                                Spacer(modifier = Modifier.width(4.dp))
+                            } else {
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                        }
+                    }
                 }
             }
             Spacer(modifier = Modifier.weight(1f))
@@ -257,14 +284,13 @@ fun ExplorerScreen(
 @Preview
 @Composable
 fun PreviewExplorerScreen() {
-    PeerTheme {
-        val photo = stringResource(R.string.photo_label)
-        ExplorerScreen(
-            remember { mutableStateOf(photo) },
-            remember { mutableStateOf(UiAttachment.Text) },
-            {},
-            {},
-            {}
-        ) { Box(modifier = Modifier.fillMaxSize()) }
-    }
+    val photo = stringResource(R.string.photo_label)
+    ExplorerScreen(
+        title = remember { mutableStateOf(photo) },
+        attachment = remember { mutableStateOf(UiAttachment.Text) },
+        onClick = {},
+        onFinish = {},
+        onSelect = {},
+        content = {}
+    )
 }


### PR DESCRIPTION
# 📌 Background
Currently, the Upload Media screen only shows a plain text label next to the media upload UI, which is not intuitive for users. There's no visual hint or dropdown behavior to help users quickly switch between media types (Photos, Videos, Files). Users might find this unclear or miss options. Enhancing the dropdown with recognizable icons (already available in drawable) will improve UX by making media options more discoverable and visually appealing.
## 🎯 Goal
Implement a dropdown component beside the media upload UI that displays selectable media types (Photos, Videos, Files) using corresponding icons from the drawable resources.
## ✅ Acceptance Criteria

- Dropdown is placed next to the media upload section.
- Dropdown displays the following items:
- 📷 Photo (with drawable/photo_icon)
- 🎥 Video (with drawable/video_icon)
- 📁 File (with drawable/wallet_icon)
- Each dropdown item includes both an icon and label.
- Clicking a dropdown item updates the selected media type.
- The selected media type is displayed in the dropdown header.
- UI uses Jetpack Compose and follows app’s design system.
- Component is responsive on different screen sizes.
- Icons must use existing drawables already available in the project.

## 🔗 Dependencies

- drawable/ic_photo, drawable/ic_video, drawable/ic_caret_down, drawable/ic_wallet 
- Media upload logic (to be linked with selected type, if applicable)
- UI/UX design consistency from Design system team

## 🧪 Testing Notes

- [ ] Test dropdown functionality on different screen sizes.
- [ ] Verify icons render properly and match the correct media type.
- [ ] Check selection persists correctly while interacting with the screen.
- [ ] Validate tap interaction works without delay.
- [ ] Ensure no crashes or UI overlaps during fast interaction or screen rotation.
