### PR TITLE
feat(annotation): support clickable www. links as URLs

### DIFF
--- a/core/ui/src/main/kotlin/eu/peernetwork/core/ui/usecase/AnnotationUsecase.kt
+++ b/core/ui/src/main/kotlin/eu/peernetwork/core/ui/usecase/AnnotationUsecase.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 class AnnotationUsecase @Inject constructor() : ParameterizedImmediateUseCase<String, AnnotatedString> {
     override fun invoke(param: String): AnnotatedString {
-        val pattern = Regex("""(@\w+)|(#\w+)|((https?|ftp)://[^\s]+)""", RegexOption.IGNORE_CASE)
+        val pattern = Regex("""(@\w+)|(#\w+)|((https?|ftp)://[^\s]+)|(www\.[^\s]+)""", RegexOption.IGNORE_CASE)
         return buildAnnotatedString {
             val matches = pattern.findAll(param)
             var lastIndex = 0
@@ -18,12 +18,13 @@ class AnnotationUsecase @Inject constructor() : ParameterizedImmediateUseCase<St
                 val value = match.value
                 append(param.substring(lastIndex, match.range.first))
                 val annotationTag = when {
-                    value.startsWith("http", true) || value.startsWith("ftp", true) -> "URL"
+                    value.startsWith("http", true) || value.startsWith("ftp", true) || value.startsWith("www.", true) -> "URL"
                     value.startsWith("@") -> "MENTION"
                     value.startsWith("#") -> "HASHTAG"
                     else -> "PLAIN"
                 }
-                pushStringAnnotation(tag = annotationTag, annotation = value)
+                val annotationValue = if (value.startsWith("www.", true)) "https://$value" else value
+                pushStringAnnotation(tag = annotationTag, annotation = annotationValue)
                 if (annotationTag != "PLAIN") {
                     withStyle(style = SpanStyle(color = PrimaryColor)) {
                         append(value)


### PR DESCRIPTION
## Purpose

- Update `AnnotationUsecase` to recognize `www.`-style links as URLs (alongside existing http, https, ftp links).
- All www.* links (including domains like .de, .in, etc) are now styled in blue and clickable.

## Details

- Regex was updated to include `(www\.[^\s]+)`.
- Matches for www. will now be given a `URL` annotation and are styled with PrimaryColor (blue).
- If a match starts with "www.", the annotation's value is prefixed with `https://` for better browser compatibility.
- No changes to handling of @mentions or #hashtags.

## Testing

- Any text containing `www.google.de`, `www.example.in`, `www.site.org` is now blue and opens in browser when clicked.
- Mentions and hashtags continue to work as before.
