### PR TITLE
bug(patch)- privacy policy screen blank with no display

### DIFF
--- a/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyScreen.kt
+++ b/app/src/main/kotlin/eu/peernetwork/app/ui/privacy/PrivacyScreen.kt
@@ -26,7 +26,7 @@ fun PrivacyScreen(
             webViewClient = WebViewClient()
         })
     }
-    val link = remember { mutableStateOf<String?>(null) }
+    val link = remember(url) { mutableStateOf<String?>(url) }
     Column(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION

  ## Fixes a blank screen on the Privacy Policy screen by initializing the link state with the passed URL so the WebView is actually composed.
- Root cause
  - link was initialized to null and never updated, so Crossfade’s target stayed null and the AndroidView (WebView) was never created.
- What changed
  - Initialize link with the incoming url:
    - val link = remember(url) { mutableStateOf<String?>(url) }

- Test Notes:
  1. Navigate to the Privacy Policy screen.
  2. Verify the FreePrivacyPolicy page loads and is scrollable.
  3. Press back and confirm navigation works as before.