### PR TITLE
Post count lisitng infinite loop patch

### DIFF
--- a/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/usecase/InteractorUsecase.kt
+++ b/blog/ui/src/main/kotlin/eu/peernetwork/blog/ui/usecase/InteractorUsecase.kt
@@ -44,7 +44,7 @@ class InteractorUsecase @Inject constructor(
             ContentInteractorUsecase.Parameter(
                 id = param.id,
                 engagement = param.engagement,
-                page = param.page
+                page = currentPage
             )
         )
         if (response.items.isEmpty() && currentPage.offset == 0) {


### PR DESCRIPTION
Fix paging logic to use correct offset for each page request

Previously, the paging source always used the initial offset, causing the same set of users to repeat on each page. Now, the correct offset is passed for every page fetch, ensuring unique users are loaded as the list is scrolled.