### PR TITLE
Wisdom/feat/unified discord notification

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -119,27 +119,6 @@ jobs:
           name: app-release
           path: app/build/outputs/apk/release/app-release.apk
 
-  determine_event_type:
-    name: Determine Discord Event Type
-    runs-on: ubuntu-latest
-    needs: [check_branch_sync, gitleaks, trivy_scan, build]
-    outputs:
-      event_type: ${{ steps.set_type.outputs.event_type }}
-    steps:
-      - id: set_type
-        run: |
-          if [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
-            echo "event_type=behind" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.gitleaks.result }}" == "failure" ]; then
-            echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.trivy_scan.outputs.has_findings }}" == "true" ]; then
-            echo "event_type=trivy_vulnerabilities" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build.result }}" == "failure" ]; then
-            echo "event_type=build_failed" >> $GITHUB_OUTPUT
-          else
-            echo "event_type=success" >> $GITHUB_OUTPUT
-          fi
-
   map_pr_to_discord:
     name: Map PR to Discord User
     runs-on: ubuntu-latest
@@ -171,6 +150,27 @@ jobs:
               echo "discord_mention=<@1362087975906967736>" >> $GITHUB_OUTPUT
               ;;
           esac
+
+  determine_event_type:
+    name: Determine Discord Event Type
+    runs-on: ubuntu-latest
+    needs: [check_branch_sync, gitleaks, trivy_scan, build]
+    outputs:
+      event_type: ${{ steps.set_type.outputs.event_type }}
+    steps:
+      - id: set_type
+        run: |
+          if [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
+            echo "event_type=behind" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.gitleaks.result }}" == "failure" ]; then
+            echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.trivy_scan.outputs.has_findings }}" == "true" ]; then
+            echo "event_type=trivy_vulnerabilities" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.build.result }}" == "failure" ]; then
+            echo "event_type=build_failed" >> $GITHUB_OUTPUT
+          else
+            echo "event_type=success" >> $GITHUB_OUTPUT
+          fi
 
   send_discord_notification:
     name: Unified Discord Notification

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -173,7 +173,6 @@ jobs:
           fi
   send_discord_notification:
     name: Unified Discord Notification
-    runs-on: ubuntu-latest
     needs: [check_branch_sync, gitleaks, trivy_scan, build, map_pr_to_discord, determine_event_type]
     if: always()
     uses: peer-network/.github/.github/workflows/discord-notify.yml@main

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -175,14 +175,7 @@ jobs:
   send_discord_notification:
     name: Unified Discord Notification
     runs-on: ubuntu-latest
-    needs: [
-      check_branch_sync,
-      gitleaks,
-      trivy_scan,
-      build,
-      map_pr_to_discord,
-      determine_event_type
-    ]
+    needs: [check_branch_sync,gitleaks,trivy_scan,build,map_pr_to_discord,determine_event_type]
     if: always()
     uses: peer-network/.github/.github/workflows/discord-notify.yml@main
     with:

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -48,27 +48,6 @@ jobs:
     with:
       scan_target: .
 
-  determine_event_type:
-    name: Determine Discord Event Type
-    runs-on: ubuntu-latest
-    needs: [check_branch_sync, gitleaks, trivy_scan, build]
-    outputs:
-      event_type: ${{ steps.set_type.outputs.event_type }}
-    steps:
-      - id: set_type
-        run: |
-          if [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
-            echo "event_type=behind" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.gitleaks.result }}" == "failure" ]; then
-            echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.trivy_scan.outputs.has_findings }}" == "true" ]; then
-            echo "event_type=trivy_vulnerabilities" >> $GITHUB_OUTPUT
-          elif [ "${{ needs.build.result }}" == "failure" ]; then
-            echo "event_type=build_failed" >> $GITHUB_OUTPUT
-          else
-            echo "event_type=success" >> $GITHUB_OUTPUT
-          fi
-
   build:
     runs-on: ubuntu-latest
     needs: [check_branch_sync, gitleaks, trivy_scan]
@@ -139,6 +118,27 @@ jobs:
         with:
           name: app-release
           path: app/build/outputs/apk/release/app-release.apk
+
+  determine_event_type:
+    name: Determine Discord Event Type
+    runs-on: ubuntu-latest
+    needs: [check_branch_sync, gitleaks, trivy_scan, build]
+    outputs:
+      event_type: ${{ steps.set_type.outputs.event_type }}
+    steps:
+      - id: set_type
+        run: |
+          if [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
+            echo "event_type=behind" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.gitleaks.result }}" == "failure" ]; then
+            echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.trivy_scan.outputs.has_findings }}" == "true" ]; then
+            echo "event_type=trivy_vulnerabilities" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.build.result }}" == "failure" ]; then
+            echo "event_type=build_failed" >> $GITHUB_OUTPUT
+          else
+            echo "event_type=success" >> $GITHUB_OUTPUT
+          fi
 
   map_pr_to_discord:
     name: Map PR to Discord User

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -171,13 +171,12 @@ jobs:
           else
             echo "event_type=success" >> $GITHUB_OUTPUT
           fi
-
   send_discord_notification:
     name: Unified Discord Notification
     runs-on: ubuntu-latest
     needs: [check_branch_sync, gitleaks, trivy_scan, build, map_pr_to_discord, determine_event_type]
     if: always()
-    uses: peer-network/.guthub/.github/workflows/discord-notify.yml@main
+    uses: peer-network/.github/.github/workflows/discord-notify.yml@main
     with:
       repo_name: "Android Frontend"
       event_type: ${{ needs.determine_event_type.outputs.event_type }}
@@ -185,8 +184,8 @@ jobs:
       pr_url: ${{ github.event.pull_request.html_url }}
       run_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       discord_mention: ${{ needs.map_pr_to_discord.outputs.discord_mention }}
-      secrets:
-        webhook: ${{ secrets.ANDROID_DISCORD }}
+    secrets:
+      webhook: ${{ secrets.ANDROID_DISCORD }}
 
   final_check:
     name: Final Check — Block Merge if Any Critical Job Failed

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -175,9 +175,9 @@ jobs:
   send_discord_notification:
     name: Unified Discord Notification
     runs-on: ubuntu-latest
-    needs: [check_branch_sync,gitleaks,trivy_scan,build,map_pr_to_discord,determine_event_type]
+    needs: [check_branch_sync, gitleaks, trivy_scan, build, map_pr_to_discord, determine_event_type]
     if: always()
-    uses: peer-network/.github/.github/workflows/discord-notify.yml@main
+    uses: peer-network/.guthub/.github/workflows/discord-notify.yml@main
     with:
       repo_name: "Android Frontend"
       event_type: ${{ needs.determine_event_type.outputs.event_type }}
@@ -185,8 +185,8 @@ jobs:
       pr_url: ${{ github.event.pull_request.html_url }}
       run_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
       discord_mention: ${{ needs.map_pr_to_discord.outputs.discord_mention }}
-    secrets:
-      webhook: ${{ secrets.ANDROID_DISCORD }}
+      secrets:
+        webhook: ${{ secrets.ANDROID_DISCORD }}
 
   final_check:
     name: Final Check — Block Merge if Any Critical Job Failed

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -48,6 +48,27 @@ jobs:
     with:
       scan_target: .
 
+  determine_event_type:
+    name: Determine Discord Event Type
+    runs-on: ubuntu-latest
+    needs: [check_branch_sync, gitleaks, trivy_scan, build]
+    outputs:
+      event_type: ${{ steps.set_type.outputs.event_type }}
+    steps:
+      - id: set_type
+        run: |
+          if [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
+            echo "event_type=behind" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.gitleaks.result }}" == "failure" ]; then
+            echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.trivy_scan.outputs.has_findings }}" == "true" ]; then
+            echo "event_type=trivy_vulnerabilities" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.build.result }}" == "failure" ]; then
+            echo "event_type=build_failed" >> $GITHUB_OUTPUT
+          else
+            echo "event_type=success" >> $GITHUB_OUTPUT
+          fi
+
   build:
     runs-on: ubuntu-latest
     needs: [check_branch_sync, gitleaks, trivy_scan]
@@ -154,90 +175,25 @@ jobs:
   send_discord_notification:
     name: Unified Discord Notification
     runs-on: ubuntu-latest
-    needs: [check_branch_sync, gitleaks, trivy_scan, build, map_pr_to_discord]
+    needs: [
+      check_branch_sync,
+      gitleaks,
+      trivy_scan,
+      build,
+      map_pr_to_discord,
+      determine_event_type
+    ]
     if: always()
-    steps:
-      - name: Determine message type
-        id: decide
-        run: |
-          is_behind="${{ needs.check_branch_sync.outputs.is_behind }}"
-          gitleaks_result="${{ needs.gitleaks.result }}"
-          trivy_findings="${{ needs.trivy_scan.outputs.has_findings }}"
-          build_result="${{ needs.build.result }}"
-          
-          type="none"
-          if [ "$is_behind" == "true" ]; then
-            type="behind"
-          elif [ "$gitleaks_result" == "failure" ]; then
-            type="gitleaks_failed"
-          elif [ "$trivy_findings" == "true" ]; then
-            type="trivy_vulnerabilities"
-          elif [ "$build_result" == "failure" ]; then
-            type="build_failed"
-          elif [ "$build_result" == "success" ]; then
-            type="success"
-          fi
-          echo "type=$type" >> $GITHUB_OUTPUT
-
-      - name: Send Discord Notification
-        if: steps.decide.outputs.type != 'none'
-        env:
-          ANDROID_DISCORD: ${{ secrets.ANDROID_DISCORD }}
-          DISCORD_MENTION: ${{ needs.map_pr_to_discord.outputs.discord_mention }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          case "${{ steps.decide.outputs.type }}" in
-            behind)
-              MESSAGE=":warning: **Android PR Branch is Behind the Base Branch**\n"
-              MESSAGE+="**PR:** $PR_TITLE\n"
-              MESSAGE+="Link: <$PR_URL>\n"
-              MESSAGE+="Author: $DISCORD_MENTION\n"
-              MESSAGE+="Please update your branch with the latest changes from \`${{ github.event.pull_request.base.ref }}\`."
-              ;;
-            gitleaks_failed)
-              MESSAGE=":x: **Android Gitleaks Scan Failed!**\n"
-              MESSAGE+="**PR:** $PR_TITLE\n"
-              MESSAGE+="PR Link: <$PR_URL>\n"
-              MESSAGE+="CI Run: <$RUN_URL>\n"
-              MESSAGE+="Author: $DISCORD_MENTION\n\n"
-              MESSAGE+=":warning: **Secrets were detected by Gitleaks.**\n"
-              MESSAGE+="You can:\n"
-              MESSAGE+="- [Click here to view workflow artifacts](<$RUN_URL>) (download the **gitleaks-report** artifact)\n"
-              MESSAGE+="- Check the **Actions → Artifacts** tab to view/download the report\n\n"
-              MESSAGE+=":no_entry: **Reminder:** Do NOT bypass with \`git commit --no-verify\`. CI will still block your PR.\n"
-              MESSAGE+="If this secret is actually required (false positive or approved usage), please contact **CTO / Team Lead / DevOps** for approval and whitelisting."
-              ;;
-            trivy_vulnerabilities)
-              MESSAGE="**Trivy found HIGH or CRITICAL vulnerabilities in Android Frontend!**\n"
-              MESSAGE+="**Do NOT ignore this finding — inform your Team Lead or CTO immediately.**\n"
-              MESSAGE+="View the **Trivy report artifact** in the Actions run for full details.\n"
-              MESSAGE+="**PR:** $PR_TITLE\nLink: <$PR_URL>\nRun: <$RUN_URL>\nAuthor: $DISCORD_MENTION\n\n"
-              MESSAGE+="<@1354048093376610366> <@1334087880833892392> <@1362087975906967736>"
-              ;;
-            build_failed)
-              MESSAGE=":x: **Android Build or Tests Failed**\n"
-              MESSAGE+="**PR:** $PR_TITLE\n"
-              MESSAGE+="PR Link: <$PR_URL>\n"
-              MESSAGE+="CI Run: <$RUN_URL>\n"
-              MESSAGE+="Author: $DISCORD_MENTION\n"
-              MESSAGE+="Please review your Gradle build and unit test logs."
-              ;;
-            success)
-              MESSAGE=":white_check_mark: **Android CI Passed Successfully**\n"
-              MESSAGE+="**PR:** $PR_TITLE\n"
-              MESSAGE+="PR Link: <$PR_URL>\n"
-              MESSAGE+="CI Run: <$RUN_URL>\n\n"
-              MESSAGE+="All checks passed successfully.\n"
-              MESSAGE+="Team Lead: <@1354048093376610366>"
-              ;;
-          esac
-
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d "{\"content\": \"$MESSAGE\"}" \
-               "$ANDROID_DISCORD"
+    uses: peer-network/.github/.github/workflows/discord-notify.yml@main
+    with:
+      repo_name: "Android Frontend"
+      event_type: ${{ needs.determine_event_type.outputs.event_type }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      run_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      discord_mention: ${{ needs.map_pr_to_discord.outputs.discord_mention }}
+    secrets:
+      webhook: ${{ secrets.ANDROID_DISCORD }}
 
   final_check:
     name: Final Check — Block Merge if Any Critical Job Failed


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This update integrates the new centralized Discord notification system from the .github repository. The goal is to unify CI messaging, improve consistency across repos, and automatically tag the correct Android team lead on successful CI runs.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Replaced the old inline Discord notification logic with the reusable workflow discord-notify.yml. Added event type mapping, passed the correct repo name, and ensured CI outputs flow properly into the shared notification system.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->



### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->



### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
