### PR TITLE
changed to use pr base and head

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -16,7 +16,8 @@ jobs:
     name: Auto-Update PR Branch
     uses: peer-network/.github/.github/workflows/auto-update-pr.yml@main
     with:
-      pull_request: ${{ toJson(github.event.pull_request) }}
+      pr_base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
+      pr_head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
     secrets: inherit
 
   check_branch_sync:


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

The auto-update workflow for PR branches was improved in the shared .github repo.
To enable this behavior in Android Frontend, the workflow now needs to pass the PR base and head branches into the reusable workflow.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Added the required pr_base and pr_head inputs to the auto_update_branch job so the reusable auto-update workflow can correctly detect and update outdated PR branches.
This removes the previous JSON-based approach and avoids YAML escaping issues.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Updated Security Scan workflow to pass:

pr_base: ${{ github.event.pull_request.base.ref }}

pr_head: ${{ github.event.pull_request.head.ref }}

No logic changes to CI jobs themselves.

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

This update ensures PR branches auto-sync with development or main before running CI.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
