### PR TITLE
Integrate Branch Sync Reusable Workflow and Auto-Update Conflict Alerts

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -22,29 +22,11 @@ jobs:
 
   check_branch_sync:
     name: Check if PR Branch is Behind Base
-    runs-on: ubuntu-latest
     needs: [auto_update_branch]
-    outputs:
-      is_behind: ${{ steps.check.outputs.is_behind }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Fetch all branches
-        run: git fetch origin +refs/heads/*:refs/remotes/origin/*
-
-      - id: check
-        run: |
-          base_branch="${{ github.event.pull_request.base.ref }}"
-          pr_branch="${{ github.event.pull_request.head.ref }}"
-          behind=$(git rev-list --left-right --count origin/${base_branch}...origin/${pr_branch} | awk '{print $1}')
-          if [ "$behind" -gt 0 ]; then
-            echo "is_behind=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_behind=false" >> $GITHUB_OUTPUT
-          fi
+    uses: peer-network/.github/.github/workflows/check-branch-sync.yml@main
+    with:
+      base_branch: ${{ github.event.pull_request.base.ref }}
+      pr_branch: ${{ github.event.pull_request.head.ref }}
 
   fail_outdated_branch:
     name: Block CI Due to Outdated Branch
@@ -59,7 +41,6 @@ jobs:
   map_pr_to_discord:
     name: Map PR to Discord User
     runs-on: ubuntu-latest
-    needs: [auto_update_branch]
     outputs:
       discord_mention: ${{ steps.map.outputs.discord_mention }}
     steps:
@@ -99,8 +80,8 @@ jobs:
 
   trivy_scan:
     name: Run Trivy Security Scan
-    needs: [auto_update_branch, gitleaks, map_pr_to_discord]
-    if: needs.gitleaks.result == 'success'
+    needs: [auto_update_branch,check_branch_sync, gitleaks, map_pr_to_discord]
+    if: needs.check_branch_sync.outputs.is_behind == 'false' && needs.gitleaks.result == 'success'
     uses: peer-network/.github/.github/workflows/trivy-scan.yml@main
     with:
       scan_target: .
@@ -185,7 +166,9 @@ jobs:
     steps:
       - id: set_type
         run: |
-          if [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
+          if [ "${{ needs.auto_update_branch.outputs.auto_update_conflict }}" == "true" ]; then
+            echo "event_type=auto_update_conflict" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.check_branch_sync.outputs.is_behind }}" == "true" ]; then
             echo "event_type=behind" >> $GITHUB_OUTPUT
           elif [ "${{ needs.gitleaks.result }}" == "failure" ]; then
             echo "event_type=gitleaks_failed" >> $GITHUB_OUTPUT


### PR DESCRIPTION


<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

To improve CI reliability and make branch status more transparent across all frontend repos, the workflow now includes a reusable branch-sync check and enhanced auto-update conflict detection. This ensures developers immediately see when their PR is behind or cannot be auto-updated due to merge conflicts.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Integrated the shared check-branch-sync reusable workflow and updated the auto-update logic to output a merge conflict state. The determine_event_type job now sends a dedicated Discord notification when auto-update fails due to conflicts, guiding developers to resolve them either locally or via GitHub’s conflict editor.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added check-branch-sync reusable workflow before running security or build steps.
Added support for auto_update_conflict output from the reusable auto-update workflow.
Updated determine_event_type to emit a new auto_update_conflict event.
Discord notifier now reports merge conflict failures with clear action instructions.

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

Ensures CI remains consistent across repos and provides clearer developer feedback when branches are outdated or blocked by conflicts.

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
