### PR TITLE
Added soft auto label

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -12,6 +12,60 @@ on:
       - development
 
 jobs:
+  auto_label:
+    name: Auto Label PR
+    if: github.event_name == 'pull_request'
+    uses: peer-network/.github/.github/workflows/auto-label.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      mode: soft
+      label_config: |
+        {
+          ".github/workflows/.*": "ci",
+          ".githooks/.*": "ci",
+
+          ".security/.*": "security",
+
+          "app/.*": "android",
+          "blog/.*": "android",
+          "core/.*": "android",
+          "media/.*": "android",
+          "messaging/.*": "android",
+          "persistence/.*": "android",
+          "social/.*": "android",
+          "user/.*": "android",
+          "wallet/.*": "android",
+
+          "app/src/test/.*": "tests",
+          "blog/.*/test/.*": "tests",
+          "core/.*/test/.*": "tests",
+          "media/.*/test/.*": "tests",
+          "social/.*/test/.*": "tests",
+          "user/.*/test/.*": "tests",
+          "wallet/.*/test/.*": "tests",
+
+          "app/src/main/res/.*": "assets",
+          "blog/.*/res/.*": "assets",
+          "core/.*/res/.*": "assets",
+          "media/.*/res/.*": "assets",
+          "social/.*/res/.*": "assets",
+          "user/.*/res/.*": "assets",
+          "wallet/.*/res/.*": "assets",
+
+          "^build.gradle.kts$": "build",
+          "^settings.gradle.kts$": "build",
+          "^gradle.properties$": "build",
+          "^gradlew$": "build",
+          "^gradlew.bat$": "build",
+          "^package-lock.json$": "build",
+
+          "gradle/.*": "build",
+          ".*\\.gradle\\.kts$": "build",
+
+          "README.*": "documentation"
+        }
+
   auto_update_branch:
     name: Auto-Update PR Branch
     uses: peer-network/.github/.github/workflows/auto-update-pr.yml@main


### PR DESCRIPTION
<!-- If this is a RELEASE-PR please add the Versioning to it! (Version X.X.X) -->

### Context
<!-- WHY: product/user rationale, background, goals. Keep to ~3–6 sentences. -->

This change introduces automated pull-request labeling for the Android repository to improve visibility and review routing.
As the Android codebase spans multiple modules and shared components, manual labeling was inconsistent and time-consuming.
Automatic labels help reviewers immediately understand the scope of a PR (Android code, tests, build tooling, assets, security, or documentation) without extra effort.
The feature is enabled in soft mode to avoid blocking or enforcement.

### Description
<!-- HOW: implementation summary. Mention service integrations, jobs/cron, data/schema changes,
     feature flags, migrations, rollout/rollback steps. -->

Integrated the reusable organization-wide Auto-Label PR GitHub Action into the Android CI workflow.
Labels are applied based on changed file paths (modules, tests, assets, Gradle/build files, CI, and security config).
The workflow runs only on pull requests, has no impact on push builds, and does not affect CI outcomes.
This lays the foundation for smarter CI routing and clearer reviewer ownership in future iterations.

### Changes in the codebase (optional)
<!-- Reusable snippets, new utilities, notable patterns. Link to files/lines if helpful. -->

Added auto_label job using the shared auto-label.yml reusable workflow
Defined Android-specific label_config for modules, tests, assets, build files, and security folders
Scoped execution to PR events only (non-restrictive / soft mode)

### Additional information (optional)
<!-- Performance considerations, trade-offs, edge cases, limitations. -->

No behavior change to builds or tests
No breaking changes
Labels are informational only and can be extended later if needed

### Links
<!-- Tickets and docs -->
- ClickUp:
- Additional:
